### PR TITLE
[feature] translate (sample)

### DIFF
--- a/sample/logging-deepl.md
+++ b/sample/logging-deepl.md
@@ -1,0 +1,600 @@
+# Logging
+
+- [Introduction](#introduction)
+- [Configuration](#configuration)
+    - [Available Channel Drivers](#available-channel-drivers)
+    - [Channel Prerequisites](#channel-prerequisites)
+    - [Logging Deprecation Warnings](#logging-deprecation-warnings)
+- [Building Log Stacks](#building-log-stacks)
+- [Writing Log Messages](#writing-log-messages)
+    - [Contextual Information](#contextual-information)
+    - [Writing to Specific Channels](#writing-to-specific-channels)
+- [Monolog Channel Customization](#monolog-channel-customization)
+    - [Customizing Monolog for Channels](#customizing-monolog-for-channels)
+    - [Creating Monolog Handler Channels](#creating-monolog-handler-channels)
+    - [Creating Custom Channels via Factories](#creating-custom-channels-via-factories)
+- [Tailing Log Messages Using Pail](#tailing-log-messages-using-pail)
+    - [Installation](#pail-installation)
+    - [Usage](#pail-usage)
+    - [Filtering Logs](#pail-filtering-logs)
+
+<a name="소개"></a>
+## Introduction
+
+애플리케이션 내에서 일어나는 일에 대해 자세히 알 수 있도록 Laravel은 파일, 시스템 오류 로그, 심지어 Slack에 메시지를 기록하여 전체 팀에 알릴 수 있는 강력한 로깅 서비스를 제공합니다.
+
+Laravel 로깅은 "채널"을 기반으로 합니다. 각 채널은 로그 정보를 기록하는 특정 방법을 나타냅니다. 예를 들어, `단일` 채널은 단일 로그 파일에 로그 파일을 작성하고, `슬랙` 채널은 로그 메시지를 Slack으로 보냅니다. 로그 메시지는 심각도에 따라 여러 채널에 기록될 수 있습니다.
+
+내부적으로 Laravel은 다양하고 강력한 로그 핸들러를 지원하는 [Monolog](https://github.com/Seldaek/monolog) 라이브러리를 활용합니다. Laravel을 사용하면 이러한 핸들러를 쉽게 구성할 수 있으므로 애플리케이션의 로그 처리를 사용자 정의하기 위해 혼합 및 조합할 수 있습니다.
+
+<a name="configuration"></a>
+## Configuration
+
+애플리케이션의 로깅 동작을 제어하는 모든 구성 옵션은 `config/logging.php` 구성 파일에 있습니다. 이 파일을 통해 애플리케이션의 로그 채널을 구성할 수 있으므로 사용 가능한 각 채널과 해당 옵션을 검토해야 합니다. 아래에서 몇 가지 일반적인 옵션을 검토하겠습니다.
+
+기본적으로 Laravel은 메시지를 로깅할 때 `stack` 채널을 사용합니다. 스택` 채널은 여러 로그 채널을 단일 채널로 집계하는 데 사용됩니다. 스택 구축에 대한 자세한 내용은 [아래 문서](#건물-로그-스택)를 참조하세요.
+
+<a name="available-channel-drivers"></a>
+### Available Channel Drivers
+
+각 로그 채널은 '드라이버'에 의해 구동됩니다. 드라이버는 로그 메시지가 실제로 기록되는 방법과 위치를 결정합니다. 다음 로그 채널 드라이버는 모든 Laravel 애플리케이션에서 사용할 수 있습니다. 대부분의 드라이버에 대한 항목은 애플리케이션의 `config/logging.php` 구성 파일에 이미 존재하므로 이 파일을 검토하여 내용을 숙지하세요:
+
+<div class="overflow-auto">
+
+| 이름 | 설명 |
+| ------------ | -------------------------------------------------------------------- |
+| `custom` | 지정된 팩토리를 호출하여 채널을 생성하는 드라이버입니다.         |
+| 매일` | 매일 회전하는 `RotatingFileHandler` 기반 Monolog 드라이버입니다.    |
+| `errorlog` | `ErrorLogHandler` 기반 Monolog 드라이버.                           |
+| `monolog` | 지원되는 모든 Monolog 핸들러를 사용할 수 있는 Monolog 팩토리 드라이버. |
+| 페이퍼트레일` | `SyslogUdpHandler` 기반 Monolog 드라이버.                           |
+| 단일` | 단일 파일 또는 경로 기반 로거 채널(`StreamHandler`).        |
+| slack` | `SlackWebhookHandler` 기반 Monolog 드라이버.                        |
+| `stack` | "다중 채널" 채널을 쉽게 생성하기 위한 래퍼.           |
+| `syslog` | `SyslogHandler` 기반 Monolog 드라이버.                              |
+
+</div>
+
+> [!NOTE]
+> 고급 채널 사용자 정의](#monolog-channel-customization) 문서를 확인하여 `monolog` 및 `custom` 드라이버에 대해 자세히 알아보세요.
+
+<a name="configuring-the-channel-name"></a>
+#### Configuring the Channel Name
+
+기본적으로 Monolog는 현재 환경과 일치하는 '채널 이름'으로 인스턴스화됩니다(예: `production` 또는 `local`). 이 값을 변경하려면 채널의 구성에 `name` 옵션을 추가하면 됩니다:
+
+```php
+'stack' => [
+    'driver' => 'stack',
+    'name' => 'channel-name',
+    'channels' => ['single', 'slack'],
+],
+```
+
+<a name="channel-pre-requisites"></a>
+### Channel Prerequisites
+
+<a name="configuring-the-single-and-daily-channels"></a>
+#### Configuring the Single and Daily Channels
+
+단일` 및 `데일리` 채널에는 세 가지 선택적 구성 옵션이 있습니다: 버블`, `퍼미션`, `잠금`의 세 가지 옵션이 있습니다.
+
+<div class="overflow-auto">
+
+| 이름 | 설명 | 기본값 |
+| ------------ | ----------------------------------------------------------------------------- | ------- |
+| `버블` | 메시지가 처리된 후 다른 채널로 버블을 발생시킬지 여부를 나타냅니다. | `true` |
+| `locking`` 로그 파일에 쓰기 전에 잠그기를 시도합니다.                            | `false` |
+| `permission` | 로그 파일의 권한입니다.                                                   | `0644` |
+
+</div>
+
+또한 `매일` 채널에 대한 보존 정책은 `LOG_DAILY_DAYS` 환경 변수를 통해 구성하거나 `days` 구성 옵션을 설정하여 구성할 수 있습니다.
+
+<div class="overflow-auto">
+
+| 이름 | 설명 | 기본값 |
+| ------ | ----------------------------------------------------------- | ------- |
+| `days` | 일일 로그 파일을 보관할 일수입니다. | `14` |
+
+</div>
+
+<a name="configuring-the-papertrail-channel"></a>
+#### Configuring the Papertrail Channel
+
+페이퍼트레일` 채널에는 `host` 및 `port` 구성 옵션이 필요합니다. 이 옵션은 `PAPERTRAIL_URL` 및 `PAPERTRAIL_PORT` 환경 변수를 통해 정의할 수 있습니다. 이 값은 [Papertrail](https://help.papertrailapp.com/kb/configuration/configuring-centralized-logging-from-php-apps/#send-events-from-php-app)에서 얻을 수 있습니다.
+
+<a name="configuring-the-slack-channel"></a>
+#### Configuring the Slack Channel
+
+슬랙` 채널에는 `url` 구성 옵션이 필요합니다. 이 값은 `LOG_SLACK_WEBHOOK_URL` 환경 변수를 통해 정의할 수 있습니다. 이 URL은 Slack 팀에 대해 구성한 [수신 웹훅](https://slack.com/apps/A0F7XDUAZ-incoming-webhooks)의 URL과 일치해야 합니다.
+
+기본적으로 Slack은 `critical` 수준 이상의 로그만 수신하지만 `LOG_LEVEL` 환경 변수를 사용하거나 Slack 로그 채널의 구성 배열 내에서 `level` 구성 옵션을 수정하여 이를 조정할 수 있습니다.
+
+<a name="logging-deprecation-warnings"></a>
+### Logging Deprecation Warnings
+
+PHP, Laravel 및 기타 라이브러리는 종종 일부 기능이 더 이상 사용되지 않으며 향후 버전에서 제거될 것임을 사용자에게 알립니다. 이러한 사용 중단 경고를 기록하려면 `LOG_DEPRECATIONS_CHANNEL` 환경 변수를 사용하거나 애플리케이션의 `config/logging.php` 구성 파일 내에서 선호하는 `deprecations` 로그 채널을 지정할 수 있습니다:
+
+```php
+'deprecations' => [
+    'channel' => env('LOG_DEPRECATIONS_CHANNEL', 'null'),
+    'trace' => env('LOG_DEPRECATIONS_TRACE', false),
+],
+
+'channels' => [
+    // ...
+]
+```
+
+또는 `deprecations`라는 이름의 로그 채널을 정의할 수 있습니다. 이 이름을 가진 로그 채널이 존재하면 항상 사용 중단을 기록하는 데 사용됩니다:
+
+```php
+'channels' => [
+    'deprecations' => [
+        'driver' => 'single',
+        'path' => storage_path('logs/php-deprecation-warnings.log'),
+    ],
+],
+```
+
+<a name="building-log-stacks"></a>
+## Building Log Stacks
+
+앞서 언급했듯이 `stack` 드라이버를 사용하면 편의를 위해 여러 채널을 단일 로그 채널로 결합할 수 있습니다. 로그 스택을 사용하는 방법을 설명하기 위해 프로덕션 애플리케이션에서 볼 수 있는 구성 예시를 살펴보겠습니다:
+
+```php
+'channels' => [
+    'stack' => [
+        'driver' => 'stack',
+        'channels' => ['syslog', 'slack'], // [tl! add]
+        'ignore_exceptions' => false,
+    ],
+
+    'syslog' => [
+        'driver' => 'syslog',
+        'level' => env('LOG_LEVEL', 'debug'),
+        'facility' => env('LOG_SYSLOG_FACILITY', LOG_USER),
+        'replace_placeholders' => true,
+    ],
+
+    'slack' => [
+        'driver' => 'slack',
+        'url' => env('LOG_SLACK_WEBHOOK_URL'),
+        'username' => env('LOG_SLACK_USERNAME', 'Laravel Log'),
+        'emoji' => env('LOG_SLACK_EMOJI', ':boom:'),
+        'level' => env('LOG_LEVEL', 'critical'),
+        'replace_placeholders' => true,
+    ],
+],
+```
+
+이 구성을 자세히 분석해 보겠습니다. 먼저, `stack` 채널이 `channels` 옵션을 통해 두 개의 다른 채널인 `syslog`와 `slack`을 집계한다는 점을 주목하세요. 따라서 메시지를 로깅할 때 이 두 채널 모두 메시지를 로깅할 기회를 갖게 됩니다. 그러나 아래에서 살펴보겠지만 이러한 채널이 실제로 메시지를 기록할지 여부는 메시지의 심각도/"수준"에 따라 결정될 수 있습니다.
+
+<a name="log-levels"></a>
+#### Log Levels
+
+위 예의 `syslog` 및 `slack` 채널 구성에 있는 `level` 구성 옵션에 주목하세요. 이 옵션은 채널에서 메시지를 기록하기 위해 메시지의 최소 '수준'을 결정합니다. Laravel의 로깅 서비스를 구동하는 Monolog는 [RFC 5424 사양](https://tools.ietf.org/html/rfc5424)에 정의된 모든 로그 레벨을 제공합니다. 심각도에 따라 내림차순으로 로그 레벨은 다음과 같습니다: **긴급**, **경고**, **중요**, **오류**, **경고**, **공지**, **정보**, **디버그**입니다.
+
+따라서 `debug` 메서드를 사용하여 메시지를 로깅한다고 가정해 보겠습니다:
+
+```php
+Log::debug('An informational message.');
+```
+
+이 구성에서 `syslog` 채널은 메시지를 시스템 로그에 기록하지만 오류 메시지가 `critical` 이상이 아니므로 Slack으로 전송되지 않습니다. 그러나 `긴급` 메시지를 기록하는 경우에는 `긴급` 수준이 두 채널의 최소 수준 임계값을 초과하므로 시스템 로그와 Slack 모두에 전송됩니다:
+
+```php
+Log::emergency('The system is down!');
+```
+
+<a name="writing-log-messages"></a>
+## Writing Log Messages
+
+로그` [facade](/docs/{{version}}/facades)를 사용하여 로그에 정보를 기록할 수 있습니다. 앞서 언급했듯이 로거는 [RFC 5424 사양](https://tools.ietf.org/html/rfc5424)에 정의된 8가지 로깅 수준을 제공합니다: **긴급**, **경고**, **중요**, **오류**, **경고**, **주의**, **정보**, **디버그**:
+
+```php
+use Illuminate\Support\Facades\Log;
+
+Log::emergency($message);
+Log::alert($message);
+Log::critical($message);
+Log::error($message);
+Log::warning($message);
+Log::notice($message);
+Log::info($message);
+Log::debug($message);
+```
+
+이러한 메서드 중 하나를 호출하여 해당 수준에 대한 메시지를 기록할 수 있습니다. 기본적으로 메시지는 `logging` 설정 파일에 구성된 기본 로그 채널에 기록됩니다:
+
+```php
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Log;
+use Illuminate\View\View;
+
+class UserController extends Controller
+{
+    /**
+     * Show the profile for the given user.
+     */
+    public function show(string $id): View
+    {
+        Log::info('Showing the user profile for user: {id}', ['id' => $id]);
+
+        return view('user.profile', [
+            'user' => User::findOrFail($id)
+        ]);
+    }
+}
+```
+
+<a name="contextual-information"></a>
+### Contextual Information
+
+컨텍스트 데이터 배열이 로그 메서드에 전달될 수 있습니다. 이 컨텍스트 데이터는 형식이 지정되고 로그 메시지와 함께 표시됩니다:
+
+```php
+use Illuminate\Support\Facades\Log;
+
+Log::info('User {id} failed to login.', ['id' => $user->id]);
+```
+
+특정 채널의 모든 후속 로그 항목에 포함되어야 하는 일부 문맥 정보를 지정하고 싶을 때가 있습니다. 예를 들어 애플리케이션으로 들어오는 각 요청과 연관된 요청 ID를 기록할 수 있습니다. 이를 위해 `Log` 파사드의 `withContext` 메서드를 호출하면 됩니다:
+
+```php
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\Response;
+
+class AssignRequestId
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $requestId = (string) Str::uuid();
+
+        Log::withContext([
+            'request-id' => $requestId
+        ]);
+
+        $response = $next($request);
+
+        $response->headers->set('Request-Id', $requestId);
+
+        return $response;
+    }
+}
+```
+
+모든_ 로깅 채널에서 컨텍스트 정보를 공유하려면 `Log::shareContext()` 메서드를 호출할 수 있습니다. 이 메서드는 생성된 모든 채널과 이후에 생성되는 모든 채널에 컨텍스트 정보를 제공합니다:
+
+```php
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\Response;
+
+class AssignRequestId
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $requestId = (string) Str::uuid();
+
+        Log::shareContext([
+            'request-id' => $requestId
+        ]);
+
+        // ...
+    }
+}
+```
+
+> [!NOTE]
+> 대기 중인 작업을 처리하는 동안 로그 컨텍스트를 공유해야 하는 경우, [작업 미들웨어](/docs/{{version}}/queues#job-middleware)를 활용할 수 있습니다.
+
+<a name="특정 채널에 쓰기"></a>
+### Writing to Specific Channels
+
+애플리케이션의 기본 채널이 아닌 다른 채널에 메시지를 기록하고 싶을 때가 있습니다. 로그` 전면의 `채널` 메서드를 사용하여 구성 파일에 정의된 채널을 검색하고 해당 채널에 로깅할 수 있습니다:
+
+```php
+use Illuminate\Support\Facades\Log;
+
+Log::channel('slack')->info('Something happened!');
+```
+
+여러 채널로 구성된 온디맨드 로깅 스택을 만들려면 `stack` 메서드를 사용할 수 있습니다:
+
+```php
+Log::stack(['single', 'slack'])->info('Something happened!');
+```
+
+<a name="on-demand-channels"></a>
+#### On-Demand Channels
+
+애플리케이션의 `로깅` 구성 파일에 해당 구성이 없어도 런타임에 구성을 제공하여 온디맨드 채널을 생성할 수도 있습니다. 이를 위해 `로그` 파사드의 `build` 메서드에 구성 배열을 전달할 수 있습니다:
+
+```php
+use Illuminate\Support\Facades\Log;
+
+Log::build([
+  'driver' => 'single',
+  'path' => storage_path('logs/custom.log'),
+])->info('Something happened!');
+```
+
+온디맨드 로깅 스택에 온디맨드 채널을 포함할 수도 있습니다. 이는 `stack` 메서드에 전달된 배열에 온디맨드 채널 인스턴스를 포함하면 됩니다:
+
+```php
+use Illuminate\Support\Facades\Log;
+
+$channel = Log::build([
+  'driver' => 'single',
+  'path' => storage_path('logs/custom.log'),
+]);
+
+Log::stack(['slack', $channel])->info('Something happened!');
+```
+
+<a name="monolog-channel-customization"></a>
+## Monolog Channel Customization
+
+<a name="customizing-monolog-for-channels"></a>
+### Customizing Monolog for Channels
+
+기존 채널에 대해 Monolog가 구성되는 방식을 완전히 제어해야 하는 경우가 있습니다. 예를 들어, Laravel의 기본 제공 `단일` 채널에 대해 사용자 지정 Monolog `FormatterInterface` 구현을 구성하고 싶을 수 있습니다.
+
+시작하려면 채널의 구성에 `tap` 배열을 정의하세요. 탭` 배열에는 Monolog 인스턴스가 생성된 후 사용자 정의(또는 "탭")할 수 있는 클래스 목록이 포함되어야 합니다. 이러한 클래스를 배치해야 하는 일반적인 위치는 없으므로 애플리케이션 내에 이러한 클래스를 포함할 디렉터리를 자유롭게 생성할 수 있습니다:
+
+```php
+'single' => [
+    'driver' => 'single',
+    'tap' => [App\Logging\CustomizeFormatter::class],
+    'path' => storage_path('logs/laravel.log'),
+    'level' => env('LOG_LEVEL', 'debug'),
+    'replace_placeholders' => true,
+],
+```
+
+채널에서 '탭' 옵션을 구성했으면 이제 Monolog 인스턴스를 사용자 지정할 클래스를 정의할 준비가 된 것입니다. 이 클래스에는 `__invoke`라는 단일 메서드만 필요하며, 이 메서드는 `Illuminate\Log\Logger` 인스턴스를 수신합니다. 일루미네이트\로그\로거` 인스턴스는 모든 메서드 호출을 기본 Monolog 인스턴스로 프록시합니다:
+
+```php
+<?php
+
+namespace App\Logging;
+
+use Illuminate\Log\Logger;
+use Monolog\Formatter\LineFormatter;
+
+class CustomizeFormatter
+{
+    /**
+     * Customize the given logger instance.
+     */
+    public function __invoke(Logger $logger): void
+    {
+        foreach ($logger->getHandlers() as $handler) {
+            $handler->setFormatter(new LineFormatter(
+                '[%datetime%] %channel%.%level_name%: %message% %context% %extra%'
+            ));
+        }
+    }
+}
+```
+
+> [!NOTE]
+> 모든 "탭" 클래스는 [서비스 컨테이너](/docs/{{version}}/container)에서 해결되므로 필요한 모든 생성자 종속성이 자동으로 주입됩니다.
+
+<a name="creating-monolog-handler-channels"></a>
+### Creating Monolog Handler Channels
+
+Monolog에는 다양한 [사용 가능한 핸들러](https://github.com/Seldaek/monolog/tree/main/src/Monolog/Handler)가 있으며, Laravel에는 각 핸들러에 대한 기본 제공 채널이 포함되어 있지 않습니다. 경우에 따라 해당 Laravel 로그 드라이버가 없는 특정 Monolog 핸들러의 인스턴스일 뿐인 사용자 정의 채널을 만들고 싶을 수도 있습니다.  이러한 채널은 `monolog` 드라이버를 사용하여 쉽게 생성할 수 있습니다.
+
+Monolog` 드라이버를 사용할 때 `handler` 구성 옵션을 사용하여 인스턴스화할 핸들러를 지정합니다. 선택적으로, 처리기에 필요한 생성자 매개변수는 `handler_with` 구성 옵션을 사용하여 지정할 수 있습니다:
+
+```php
+'logentries' => [
+    'driver'  => 'monolog',
+    'handler' => Monolog\Handler\SyslogUdpHandler::class,
+    'handler_with' => [
+        'host' => 'my.logentries.internal.datahubhost.company.com',
+        'port' => '10000',
+    ],
+],
+```
+
+<a name="monolog-formatters"></a>
+#### Monolog Formatters
+
+Monolog` 드라이버를 사용하는 경우, Monolog `LineFormatter`가 기본 포맷터로 사용됩니다. 그러나 `formatter` 및 `formatter_with` 구성 옵션을 사용하여 핸들러에 전달되는 포맷터 유형을 사용자 지정할 수 있습니다:
+
+```php
+'browser' => [
+    'driver' => 'monolog',
+    'handler' => Monolog\Handler\BrowserConsoleHandler::class,
+    'formatter' => Monolog\Formatter\HtmlFormatter::class,
+    'formatter_with' => [
+        'dateFormat' => 'Y-m-d',
+    ],
+],
+```
+
+자체 포맷터를 제공할 수 있는 Monolog 핸들러를 사용하는 경우 `formatter` 구성 옵션의 값을 `default`로 설정할 수 있습니다:
+
+```php
+'newrelic' => [
+    'driver' => 'monolog',
+    'handler' => Monolog\Handler\NewRelicHandler::class,
+    'formatter' => 'default',
+],
+```
+
+<a name="monolog-processors"></a>
+#### Monolog Processors
+
+Monolog는 메시지를 로깅하기 전에 메시지를 처리할 수도 있습니다. 자체 프로세서를 만들거나 Monolog에서 제공하는 [기존 프로세서](https://github.com/Seldaek/monolog/tree/main/src/Monolog/Processor)를 사용할 수 있습니다.
+
+'monolog` 드라이버에 대한 프로세서를 사용자 지정하려면 채널의 구성에 `processors` 구성 값을 추가하세요:
+
+```php
+'memory' => [
+    'driver' => 'monolog',
+    'handler' => Monolog\Handler\StreamHandler::class,
+    'handler_with' => [
+        'stream' => 'php://stderr',
+    ],
+    'processors' => [
+        // Simple syntax...
+        Monolog\Processor\MemoryUsageProcessor::class,
+
+        // With options...
+        [
+            'processor' => Monolog\Processor\PsrLogMessageProcessor::class,
+            'with' => ['removeUsedContextFields' => true],
+        ],
+    ],
+],
+```
+
+<a name="creating-custom-channels-via-factories"></a>
+### Creating Custom Channels via Factories
+
+Monolog의 인스턴스화 및 구성을 완전히 제어할 수 있는 완전히 사용자 정의 채널을 정의하려면 `config/logging.php` 구성 파일에 `custom` 드라이버 유형을 지정할 수 있습니다. 구성에는 Monolog 인스턴스를 생성하기 위해 호출될 팩토리 클래스의 이름이 포함된 `via` 옵션이 포함되어야 합니다:
+
+```php
+'channels' => [
+    'example-custom-channel' => [
+        'driver' => 'custom',
+        'via' => App\Logging\CreateCustomLogger::class,
+    ],
+],
+```
+
+Custom` 드라이버 채널을 구성했으면 이제 Monolog 인스턴스를 생성할 클래스를 정의할 준비가 된 것입니다. 이 클래스에는 Monolog 로거 인스턴스를 반환해야 하는 단일 `__invoke` 메서드만 필요합니다. 이 메서드는 채널 구성 배열을 유일한 인수로 받습니다:
+
+```php
+<?php
+
+namespace App\Logging;
+
+use Monolog\Logger;
+
+class CreateCustomLogger
+{
+    /**
+     * Create a custom Monolog instance.
+     */
+    public function __invoke(array $config): Logger
+    {
+        return new Logger(/* ... */);
+    }
+}
+```
+
+<a name="tailing-log-messages-using-pail"></a>
+## Tailing Log Messages Using Pail
+
+애플리케이션의 로그를 실시간으로 추적해야 하는 경우가 종종 있습니다. 예를 들어 문제를 디버깅하거나 애플리케이션의 로그에서 특정 유형의 오류를 모니터링할 때입니다.
+
+Laravel Pail은 명령줄에서 직접 Laravel 애플리케이션의 로그 파일을 쉽게 살펴볼 수 있는 패키지입니다. 표준 `tail` 명령과 달리, Pail은 Sentry 또는 Flare를 포함한 모든 로그 드라이버와 함께 작동하도록 설계되었습니다. 또한 Pail은 원하는 것을 빠르게 찾을 수 있도록 유용한 필터 세트를 제공합니다.
+
+<img src="https://laravel.com/img/docs/pail-example.png">
+
+<a name="pail-installation"></a>
+### Installation
+
+> [!WARNING]
+> 라라벨 페일에는 [PHP 8.2+](https://php.net/releases/) 및 [PCNTL](https://www.php.net/manual/en/book.pcntl.php) 확장 프로그램이 필요합니다.
+
+시작하려면 Composer 패키지 관리자를 사용하여 프로젝트에 Pail을 설치하세요:
+
+```shell
+composer require laravel/pail
+```
+
+<a name="pail-usage"></a>
+### Usage
+
+로그 테일링을 시작하려면 `pail` 명령을 실행합니다:
+
+```shell
+php artisan pail
+```
+
+출력의 상세도를 높이고 잘림(...)을 방지하려면 `-v` 옵션을 사용합니다:
+
+```shell
+php artisan pail -v
+```
+
+자세한 내용을 최대화하고 예외 스택 추적을 표시하려면 `-vv` 옵션을 사용합니다:
+
+```shell
+php artisan pail -vv
+```
+
+로그 추적을 중지하려면 언제든지 `Ctrl+C`를 누르세요.
+
+<a name="pail-filtering-logs"></a>
+### Filtering Logs
+
+<a name="pail-filtering-logs-filter-option"></a>
+#### `--filter`
+
+필터` 옵션을 사용하여 로그의 유형, 파일, 메시지, 스택 추적 콘텐츠별로 로그를 필터링할 수 있습니다:
+
+```shell
+php artisan pail --filter="QueryException"
+```
+
+<a name="pail-filtering-logs-message-option"></a>
+#### `--message`
+
+메시지만 기준으로 로그를 필터링하려면 `--메시지` 옵션을 사용할 수 있습니다:
+
+```shell
+php artisan pail --message="User created"
+```
+
+<a name="pail-filtering-logs-level-option"></a>
+#### `--level`
+
+로그 수준](#log-levels)을 기준으로 로그를 필터링하려면 `--level` 옵션을 사용할 수 있습니다:
+
+```shell
+php artisan pail --level=error
+```
+
+<a name="pail-filtering-logs-user-option"></a>
+#### `--user`
+
+특정 사용자가 인증된 상태에서 작성된 로그만 표시하려면 `--사용자` 옵션에 사용자 ID를 제공하면 됩니다:
+
+```shell
+php artisan pail --user=1
+```

--- a/sample/logging-openai.md
+++ b/sample/logging-openai.md
@@ -1,0 +1,600 @@
+# Logging
+
+- [Introduction](#introduction)
+- [Configuration](#configuration)
+    - [Available Channel Drivers](#available-channel-drivers)
+    - [Channel Prerequisites](#channel-prerequisites)
+    - [Logging Deprecation Warnings](#logging-deprecation-warnings)
+- [Building Log Stacks](#building-log-stacks)
+- [Writing Log Messages](#writing-log-messages)
+    - [Contextual Information](#contextual-information)
+    - [Writing to Specific Channels](#writing-to-specific-channels)
+- [Monolog Channel Customization](#monolog-channel-customization)
+    - [Customizing Monolog for Channels](#customizing-monolog-for-channels)
+    - [Creating Monolog Handler Channels](#creating-monolog-handler-channels)
+    - [Creating Custom Channels via Factories](#creating-custom-channels-via-factories)
+- [Tailing Log Messages Using Pail](#tailing-log-messages-using-pail)
+    - [Installation](#pail-installation)
+    - [Usage](#pail-usage)
+    - [Filtering Logs](#pail-filtering-logs)
+
+<a name="introduction"></a>
+## Introduction
+
+애플리케이션 내에서 무슨 일이 일어나고 있는지 더 잘 파악할 수 있도록, Laravel은 robust한 로깅 서비스를 제공하여 메시지를 파일, 시스템 에러 로그, 심지어 Slack에도 기록하여 팀 전체에 알릴 수 있게 합니다.
+
+Laravel의 로깅은 "채널(channels)"을 기반으로 합니다. 각 채널은 로그 정보를 기록하는 특정 방식을 나타냅니다. 예를 들어, `single` 채널은 로그 파일을 단일 로그 파일에 기록하고, `slack` 채널은 로그 메시지를 Slack으로 전송합니다. 로그 메시지는 심각도에 따라 여러 채널로 기록될 수 있습니다.
+
+
+
+내부적으로, Laravel은 [Monolog](https://github.com/Seldaek/monolog) 라이브러리를 사용하며, 이는 강력한 로그 핸들러들을 다양하게 지원합니다. Laravel은 이러한 핸들러를 간편하게 설정할 수 있도록 하여, 애플리케이션의 로그 처리를 커스터마이징하기 위해 혼합해 사용할 수 있게 합니다.
+## Configuration
+
+
+
+<a name="configuration"></a>
+
+애플리케이션의 로깅 동작을 제어하는 모든 설정 옵션은 `config/logging.php` 설정 파일에 있습니다. 이 파일에서는 애플리케이션의 로그 채널을 설정할 수 있으므로, 사용 가능한 각 채널과 그 옵션을 꼭 확인하세요. 아래에서 몇 가지 일반적인 옵션을 살펴보겠습니다.
+### Available Channel Drivers
+
+
+
+<div class="overflow-auto">
+
+기본적으로, Laravel은 메시지를 기록할 때 `stack` 채널을 사용합니다. `stack` 채널은 여러 로그 채널을 하나의 채널로 통합하는 데 사용됩니다. 스택을 구성하는 방법에 대한 자세한 내용은 [아래 문서](#building-log-stacks)를 참고하세요.
+
+<a name="available-channel-drivers"></a>
+각 로그 채널은 "driver"에 의해 구동됩니다. driver는 로그 메시지가 실제로 어떻게, 어디에 기록되는지를 결정합니다. 다음의 로그 채널 드라이버들은 모든 Laravel 애플리케이션에서 사용할 수 있습니다. 대부분의 드라이버에 대한 항목은 이미 애플리케이션의 `config/logging.php` 설정 파일에 있으므로, 이 파일을 확인하여 해당 내용을 숙지하시기 바랍니다:
+
+| Name         | Description                                                          |
+| ------------ | -------------------------------------------------------------------- |
+| `custom`     | 지정된 팩토리를 호출하여 채널을 생성하는 드라이버.                  |
+| `daily`      | 매일 회전되는 `RotatingFileHandler` 기반의 Monolog 드라이버.         |
+| `errorlog`   | `ErrorLogHandler` 기반의 Monolog 드라이버.                           |
+| `monolog`    | 지원되는 모든 Monolog 핸들러를 사용할 수 있는 Monolog 팩토리 드라이버. |
+
+</div>
+
+> [!NOTE]
+| `papertrail` | `SyslogUdpHandler` 기반의 Monolog 드라이버.                          |
+
+| `single`     | 단일 파일 또는 경로 기반의 로거 채널 (`StreamHandler`).              |
+#### Configuring the Channel Name
+
+| `slack`      | `SlackWebhookHandler` 기반의 Monolog 드라이버.                       |
+
+```php
+'stack' => [
+    'driver' => 'stack',
+    'name' => 'channel-name',
+    'channels' => ['single', 'slack'],
+],
+```
+
+| `stack`      | "멀티 채널" 채널을 만들 수 있도록 하는 래퍼.                        |
+### Channel Prerequisites
+
+| `syslog`     | `SyslogHandler` 기반의 Monolog 드라이버.                             |
+#### Configuring the Single and Daily Channels
+
+
+
+<div class="overflow-auto">
+
+> [advanced channel customization](#monolog-channel-customization)에 대한 문서를 확인하여 `monolog` 및 `custom` 드라이버에 대해 더 알아보세요.
+
+<a name="configuring-the-channel-name"></a>
+기본적으로, Monolog는 현재 환경(`production` 또는 `local` 등)과 일치하는 "채널 이름"으로 인스턴스화됩니다. 이 값을 변경하려면, 채널 설정에 `name` 옵션을 추가하면 됩니다:
+
+
+</div>
+
+<a name="channel-prerequisites"></a>
+
+<div class="overflow-auto">
+
+<a name="configuring-the-single-and-daily-channels"></a>
+`single` 및 `daily` 채널에는 `bubble`, `permission`, `locking` 세 가지 선택적 설정 옵션이 있습니다.
+
+
+</div>
+
+| Name         | Description                                                                   | Default |
+#### Configuring the Papertrail Channel
+
+| ------------ | ----------------------------------------------------------------------------- | ------- |
+
+| `bubble`     | 메시지가 처리된 후 다른 채널로 전달될지 여부를 나타냅니다.                   | `true`  |
+#### Configuring the Slack Channel
+
+| `locking`    | 기록하기 전에 로그 파일을 잠그려고 시도합니다.                               | `false` |
+
+| `permission` | 로그 파일의 권한을 설정합니다.                                                | `0644`  |
+
+Additionally, the retention policy for the `daily` channel can be configured via the `LOG_DAILY_DAYS` environment variable or by setting the `days` configuration option.  
+### Logging Deprecation Warnings
+
+| Name   | Description                                                 | Default |
+
+```php
+'deprecations' => [
+    'channel' => env('LOG_DEPRECATIONS_CHANNEL', 'null'),
+    'trace' => env('LOG_DEPRECATIONS_TRACE', false),
+],
+
+'channels' => [
+    // ...
+]
+```
+
+| ------ | ----------------------------------------------------------- | ------- |
+
+```php
+'channels' => [
+    'deprecations' => [
+        'driver' => 'single',
+        'path' => storage_path('logs/php-deprecation-warnings.log'),
+    ],
+],
+```
+
+| `days` | 매일 로그 파일을 얼마나 오래(일 수) 보관할지 설정합니다.                 | `14`    |
+## Building Log Stacks
+
+
+
+```php
+'channels' => [
+    'stack' => [
+        'driver' => 'stack',
+        'channels' => ['syslog', 'slack'], // [tl! add]
+        'ignore_exceptions' => false,
+    ],
+
+    'syslog' => [
+        'driver' => 'syslog',
+        'level' => env('LOG_LEVEL', 'debug'),
+        'facility' => env('LOG_SYSLOG_FACILITY', LOG_USER),
+        'replace_placeholders' => true,
+    ],
+
+    'slack' => [
+        'driver' => 'slack',
+        'url' => env('LOG_SLACK_WEBHOOK_URL'),
+        'username' => env('LOG_SLACK_USERNAME', 'Laravel Log'),
+        'emoji' => env('LOG_SLACK_EMOJI', ':boom:'),
+        'level' => env('LOG_LEVEL', 'critical'),
+        'replace_placeholders' => true,
+    ],
+],
+```
+
+<a name="configuring-the-papertrail-channel"></a>
+
+The `papertrail` channel requires `host` and `port` configuration options. These may be defined via the `PAPERTRAIL_URL` and `PAPERTRAIL_PORT` environment variables. You can obtain these values from [Papertrail](https://help.papertrailapp.com/kb/configuration/configuring-centralized-logging-from-php-apps/#send-events-from-php-app).
+#### Log Levels
+
+
+
+<a name="configuring-the-slack-channel"></a>
+
+```php
+Log::debug('An informational message.');
+```
+
+The `slack` channel requires a `url` configuration option. This value may be defined via the `LOG_SLACK_WEBHOOK_URL` environment variable. This URL should match a URL for an [incoming webhook](https://slack.com/apps/A0F7XDUAZ-incoming-webhooks) that you have configured for your Slack team.  
+
+```php
+Log::emergency('The system is down!');
+```
+
+By default, Slack will only receive logs at the `critical` level and above; however, you can adjust this using the `LOG_LEVEL` environment variable or by modifying the `level` configuration option within your Slack log channel's configuration array.
+## Writing Log Messages
+
+
+
+```php
+use Illuminate\Support\Facades\Log;
+
+Log::emergency($message);
+Log::alert($message);
+Log::critical($message);
+Log::error($message);
+Log::warning($message);
+Log::notice($message);
+Log::info($message);
+Log::debug($message);
+```
+
+<a name="logging-deprecation-warnings"></a>
+
+```php
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Log;
+use Illuminate\View\View;
+
+class UserController extends Controller
+{
+    /**
+     * Show the profile for the given user.
+     */
+    public function show(string $id): View
+    {
+        Log::info('Showing the user profile for user: {id}', ['id' => $id]);
+
+        return view('user.profile', [
+            'user' => User::findOrFail($id)
+        ]);
+    }
+}
+```
+
+PHP, Laravel, and other libraries often notify their users that some of their features have been deprecated and will be removed in a future version. If you would like to log these deprecation warnings, you may specify your preferred `deprecations` log channel using the `LOG_DEPRECATIONS_CHANNEL` environment variable, or within your application's `config/logging.php` configuration file:  
+### Contextual Information
+
+Or, you may define a log channel named `deprecations`. If a log channel with this name exists, it will always be used to log deprecations:
+
+```php
+use Illuminate\Support\Facades\Log;
+
+Log::info('User {id} failed to login.', ['id' => $user->id]);
+```
+
+
+
+```php
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\Response;
+
+class AssignRequestId
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $requestId = (string) Str::uuid();
+
+        Log::withContext([
+            'request-id' => $requestId
+        ]);
+
+        $response = $next($request);
+
+        $response->headers->set('Request-Id', $requestId);
+
+        return $response;
+    }
+}
+```
+
+<a name="building-log-stacks"></a>
+
+```php
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\Response;
+
+class AssignRequestId
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $requestId = (string) Str::uuid();
+
+        Log::shareContext([
+            'request-id' => $requestId
+        ]);
+
+        // ...
+    }
+}
+```
+
+> [!NOTE]
+As mentioned previously, the `stack` driver allows you to combine multiple channels into a single log channel for convenience. To illustrate how to use log stacks, let's take a look at an example configuration that you might see in a production application:  
+
+Let's dissect this configuration. First, notice our `stack` channel aggregates two other channels via its `channels` option: `syslog` and `slack`. So, when logging messages, both of these channels will have the opportunity to log the message. However, as we will see below, whether these channels actually log the message may be determined by the message's severity / "level".
+### Writing to Specific Channels
+
+
+
+```php
+use Illuminate\Support\Facades\Log;
+
+Log::channel('slack')->info('Something happened!');
+```
+
+<a name="log-levels"></a>
+
+```php
+Log::stack(['single', 'slack'])->info('Something happened!');
+```
+
+Take note of the `level` configuration option present on the `syslog` and `slack` channel configurations in the example above. This option determines the minimum "level" a message must be in order to be logged by the channel. Monolog, which powers Laravel's logging services, offers all of the log levels defined in the [RFC 5424 specification](https://tools.ietf.org/html/rfc5424). In descending order of severity, these log levels are: **emergency**, **alert**, **critical**, **error**, **warning**, **notice**, **info**, and **debug**.
+#### On-Demand Channels
+
+
+
+```php
+use Illuminate\Support\Facades\Log;
+
+Log::build([
+  'driver' => 'single',
+  'path' => storage_path('logs/custom.log'),
+])->info('Something happened!');
+```
+
+So, imagine we log a message using the `debug` method:
+
+```php
+use Illuminate\Support\Facades\Log;
+
+$channel = Log::build([
+  'driver' => 'single',
+  'path' => storage_path('logs/custom.log'),
+]);
+
+Log::stack(['slack', $channel])->info('Something happened!');
+```
+
+Given our configuration, the `syslog` channel will write the message to the system log; however, since the error message is not `critical` or above, it will not be sent to Slack. However, if we log an `emergency` message, it will be sent to both the system log and Slack since the `emergency` level is above our minimum level threshold for both channels:
+## Monolog Channel Customization
+
+
+### Customizing Monolog for Channels
+
+<a name="writing-log-messages"></a>
+
+You may write information to the logs using the `Log` [facade](/docs/{{version}}/facades). As previously mentioned, the logger provides the eight logging levels defined in the [RFC 5424 specification](https://tools.ietf.org/html/rfc5424): **emergency**, **alert**, **critical**, **error**, **warning**, **notice**, **info** and **debug**:
+
+```php
+'single' => [
+    'driver' => 'single',
+    'tap' => [App\Logging\CustomizeFormatter::class],
+    'path' => storage_path('logs/laravel.log'),
+    'level' => env('LOG_LEVEL', 'debug'),
+    'replace_placeholders' => true,
+],
+```
+
+다음은 원문을 ko로 번역한 내용입니다(코드, 링크, 마크다운 구문은 그대로 유지):
+
+```php
+<?php
+
+namespace App\Logging;
+
+use Illuminate\Log\Logger;
+use Monolog\Formatter\LineFormatter;
+
+class CustomizeFormatter
+{
+    /**
+     * Customize the given logger instance.
+     */
+    public function __invoke(Logger $logger): void
+    {
+        foreach ($logger->getHandlers() as $handler) {
+            $handler->setFormatter(new LineFormatter(
+                '[%datetime%] %channel%.%level_name%: %message% %context% %extra%'
+            ));
+        }
+    }
+}
+```
+
+> [!NOTE]
+
+
+You may call any of these methods to log a message for the corresponding level. By default, the message will be written to the default log channel as configured by your `logging` configuration file:
+### Creating Monolog Handler Channels
+
+<a name="contextual-information"></a>
+
+로그 메서드에 컨텍스트 데이터 배열을 전달할 수 있습니다. 이 컨텍스트 데이터는 로그 메시지와 함께 포맷팅되어 표시됩니다:
+
+```php
+'logentries' => [
+    'driver'  => 'monolog',
+    'handler' => Monolog\Handler\SyslogUdpHandler::class,
+    'handler_with' => [
+        'host' => 'my.logentries.internal.datahubhost.company.com',
+        'port' => '10000',
+    ],
+],
+```
+
+가끔, 이후에 기록되는 모든 로그 항목에 포함되어야 하는 컨텍스트 정보를 지정하고 싶을 때가 있을 수 있습니다. 예를 들어, 애플리케이션으로 들어오는 각 요청과 연관된 요청 ID를 로깅하고 싶을 수 있습니다. 이를 위해서는 `Log` 퍼사드의 `withContext` 메서드를 호출하면 됩니다:
+#### Monolog Formatters
+
+모든 로깅 채널에 걸쳐 컨텍스트 정보를 공유하고 싶다면, `Log::shareContext()` 메서드를 호출할 수 있습니다. 이 메서드는 이미 생성된 모든 채널 및 이후에 생성되는 모든 채널에 컨텍스트 정보를 제공합니다:
+
+```php
+'browser' => [
+    'driver' => 'monolog',
+    'handler' => Monolog\Handler\BrowserConsoleHandler::class,
+    'formatter' => Monolog\Formatter\HtmlFormatter::class,
+    'formatter_with' => [
+        'dateFormat' => 'Y-m-d',
+    ],
+],
+```
+
+> 큐에 적재된 작업을 처리하면서 로그 컨텍스트를 공유해야 할 경우, [job middleware](/docs/{{version}}/queues#job-middleware)를 활용할 수 있습니다.
+
+```php
+'newrelic' => [
+    'driver' => 'monolog',
+    'handler' => Monolog\Handler\NewRelicHandler::class,
+    'formatter' => 'default',
+],
+```
+
+
+#### Monolog Processors
+
+<a name="writing-to-specific-channels"></a>
+
+때로는 애플리케이션의 기본 채널이 아닌 다른 채널에 메시지를 기록하고자 할 수 있습니다. 이 경우 `Log` 퍼사드의 `channel` 메서드를 사용하여 구성 파일에 정의된 어떤 채널이든 가져와서 로그를 기록할 수 있습니다:
+
+```php
+'memory' => [
+    'driver' => 'monolog',
+    'handler' => Monolog\Handler\StreamHandler::class,
+    'handler_with' => [
+        'stream' => 'php://stderr',
+    ],
+    'processors' => [
+        // Simple syntax...
+        Monolog\Processor\MemoryUsageProcessor::class,
+
+        // With options...
+        [
+            'processor' => Monolog\Processor\PsrLogMessageProcessor::class,
+            'with' => ['removeUsedContextFields' => true],
+        ],
+    ],
+],
+```
+
+여러 채널로 구성된 온디맨드 로깅 스택을 생성하고 싶다면, `stack` 메서드를 사용할 수 있습니다:
+### Creating Custom Channels via Factories
+
+
+
+```php
+'channels' => [
+    'example-custom-channel' => [
+        'driver' => 'custom',
+        'via' => App\Logging\CreateCustomLogger::class,
+    ],
+],
+```
+
+<a name="on-demand-channels"></a>
+
+```php
+<?php
+
+namespace App\Logging;
+
+use Monolog\Logger;
+
+class CreateCustomLogger
+{
+    /**
+     * Create a custom Monolog instance.
+     */
+    public function __invoke(array $config): Logger
+    {
+        return new Logger(/* ... */);
+    }
+}
+```
+
+애플리케이션의 `logging` 구성 파일에 없는 설정을 런타임에 제공함으로써 온디맨드 채널을 생성할 수도 있습니다. 이를 위해 `Log` 퍼사드의 `build` 메서드에 구성 배열을 전달하면 됩니다:
+## Tailing Log Messages Using Pail
+
+온디맨드 로깅 스택에 온디맨드 채널을 포함하고 싶을 수도 있습니다. 이를 위해서는 온디맨드 채널 인스턴스를 `stack` 메서드에 전달되는 배열에 포함하면 됩니다:
+
+
+
+<img src="https://laravel.com/img/docs/pail-example.png">
+
+<a name="monolog-channel-customization"></a>
+### Installation
+
+> [!WARNING]
+<a name="customizing-monolog-for-channels"></a>
+
+기존 채널에 대해 Monolog의 구성 방식을 완전히 제어해야 하는 경우가 있을 수 있습니다. 예를 들어, Laravel에 내장된 `single` 채널에 대해 사용자 정의 Monolog `FormatterInterface` 구현을 설정하고 싶을 수 있습니다.
+
+```shell
+composer require laravel/pail
+```
+
+먼저, 채널의 구성에서 `tap` 배열을 정의합니다. `tap` 배열은 Monolog 인스턴스가 생성된 후 이를 커스터마이즈(또는 '탭')할 수 있는 클래스들의 목록을 포함해야 합니다. 이 클래스들이 위치해야 할 전통적인 디렉터리는 없으므로, 애플리케이션 내에서 새로운 디렉터리를 만들어 자유롭게 저장할 수 있습니다:
+### Usage
+
+채널에서 `tap` 옵션을 설정한 뒤, 이제 Monolog 인스턴스를 커스터마이즈할 클래스를 정의할 수 있습니다. 이 클래스에는 단 하나의 메서드, 즉 `__invoke`만 필요하며, 이 메서드는 `Illuminate\Log\Logger` 인스턴스를 전달받습니다. `Illuminate\Log\Logger` 인스턴스는 내부의 Monolog 인스턴스에 모든 메서드 호출을 프록싱합니다:
+
+```shell
+php artisan pail
+```
+
+> 모든 'tap' 클래스는 [service container](/docs/{{version}}/container)에 의해 해석되므로, 필요한 생성자 종속성이 자동으로 주입됩니다.
+
+```shell
+php artisan pail -v
+```
+
+
+
+```shell
+php artisan pail -vv
+```
+
+<a name="creating-monolog-handler-channels"></a>
+
+Monolog에는 [사용 가능한 다양한 핸들러들](https://github.com/Seldaek/monolog/tree/main/src/Monolog/Handler)이 있으며, Laravel은 각각에 대한 빌트인 채널을 제공하지 않습니다. 경우에 따라, 특정 Monolog 핸들러에 해당하는 별도의 Laravel 로그 드라이버가 없을 때, 그 인스턴스만을 사용하는 커스텀 채널을 만들고 싶을 수 있습니다. 이러한 채널은 `monolog` 드라이버를 사용하여 손쉽게 생성할 수 있습니다.
+### Filtering Logs
+
+`monolog` 드라이버를 사용할 때, `handler` 구성 옵션을 통해 어떤 핸들러가 인스턴스화될지를 지정합니다. 선택적으로, 핸들러가 필요로 하는 생성자 파라미터는 `handler_with` 구성 옵션을 사용하여 지정할 수 있습니다:
+#### `--filter`
+
+
+
+```shell
+php artisan pail --filter="QueryException"
+```
+
+<a name="monolog-formatters"></a>
+#### `--message`
+
+`monolog` 드라이버를 사용할 때, 기본 포매터로 Monolog `LineFormatter`가 사용됩니다. 그러나 `formatter` 및 `formatter_with` 구성 옵션을 사용하여 핸들러에 전달되는 포매터 유형을 커스터마이징할 수 있습니다:
+
+```shell
+php artisan pail --message="User created"
+```
+
+
+#### `--level`
+
+Monolog 핸들러가 자체 포매터를 제공할 수 있는 경우, `formatter` 구성 옵션의 값을 `default`로 설정할 수 있습니다:
+
+```shell
+php artisan pail --level=error
+```
+
+
+#### `--user`
+
+<a name="monolog-processors"></a>
+
+```shell
+php artisan pail --user=1
+```

--- a/sample/logging-openai.md
+++ b/sample/logging-openai.md
@@ -1,67 +1,67 @@
-# Logging
+# 로깅
 
-- [Introduction](#introduction)
-- [Configuration](#configuration)
-    - [Available Channel Drivers](#available-channel-drivers)
-    - [Channel Prerequisites](#channel-prerequisites)
-    - [Logging Deprecation Warnings](#logging-deprecation-warnings)
-- [Building Log Stacks](#building-log-stacks)
-- [Writing Log Messages](#writing-log-messages)
-    - [Contextual Information](#contextual-information)
-    - [Writing to Specific Channels](#writing-to-specific-channels)
-- [Monolog Channel Customization](#monolog-channel-customization)
-    - [Customizing Monolog for Channels](#customizing-monolog-for-channels)
-    - [Creating Monolog Handler Channels](#creating-monolog-handler-channels)
-    - [Creating Custom Channels via Factories](#creating-custom-channels-via-factories)
-- [Tailing Log Messages Using Pail](#tailing-log-messages-using-pail)
-    - [Installation](#pail-installation)
-    - [Usage](#pail-usage)
-    - [Filtering Logs](#pail-filtering-logs)
+- [소개](#introduction)
+- [구성](#configuration)
+    - [사용 가능한 채널 드라이버](#available-channel-drivers)
+    - [채널 사전 요구 사항](#channel-prerequisites)
+    - [폐기 예정 경고 로깅](#logging-deprecation-warnings)
+- [Log 스택 빌드](#building-log-stacks)
+- [로그 메시지 작성](#writing-log-messages)
+    - [컨텍스트 정보](#contextual-information)
+    - [특정 채널로 로깅하기](#writing-to-specific-channels)
+- [Monolog 채널 커스터마이징](#monolog-channel-customization)
+    - [채널별 Monolog 커스터마이징](#customizing-monolog-for-channels)
+    - [Monolog 핸들러 채널 생성](#creating-monolog-handler-channels)
+    - [팩토리를 통한 커스텀 채널 생성](#creating-custom-channels-via-factories)
+- [Pail을 사용한 로그 테일링](#tailing-log-messages-using-pail)
+    - [설치](#pail-installation)
+    - [사용법](#pail-usage)
+    - [로그 필터링](#pail-filtering-logs)
 
 <a name="introduction"></a>
-## Introduction
+## 소개
 
-애플리케이션 내에서 무슨 일이 일어나고 있는지 더 잘 파악할 수 있도록, Laravel은 robust한 로깅 서비스를 제공하여 메시지를 파일, 시스템 에러 로그, 심지어 Slack에도 기록하여 팀 전체에 알릴 수 있게 합니다.
+애플리케이션 내에서 발생하는 일을 더 잘 파악할 수 있도록, Laravel은 견고한 로깅 서비스를 제공합니다. 이를 통해 파일, 시스템 에러 로그, 심지어 Slack 등으로 팀 전체에 로깅 메시지를 전송할 수 있습니다.
 
-Laravel의 로깅은 "채널(channels)"을 기반으로 합니다. 각 채널은 로그 정보를 기록하는 특정 방식을 나타냅니다. 예를 들어, `single` 채널은 로그 파일을 단일 로그 파일에 기록하고, `slack` 채널은 로그 메시지를 Slack으로 전송합니다. 로그 메시지는 심각도에 따라 여러 채널로 기록될 수 있습니다.
+Laravel의 로깅은 "채널"에 기반합니다. 각 채널은 로그 정보를 기록하는 특정한 방식을 의미합니다. 예를 들어, `single` 채널은 모든 로그를 하나의 파일에 기록하고, `slack` 채널은 로그 메시지를 Slack으로 전송합니다. 로그 메시지는 심각도(severity)에 따라 여러 채널에 동시에 기록될 수 있습니다.
 
-
-
-내부적으로, Laravel은 [Monolog](https://github.com/Seldaek/monolog) 라이브러리를 사용하며, 이는 강력한 로그 핸들러들을 다양하게 지원합니다. Laravel은 이러한 핸들러를 간편하게 설정할 수 있도록 하여, 애플리케이션의 로그 처리를 커스터마이징하기 위해 혼합해 사용할 수 있게 합니다.
-## Configuration
-
-
+Laravel은 내부적으로 [Monolog](https://github.com/Seldaek/monolog) 라이브러리를 사용합니다. Monolog은 다양한 강력한 로깅 핸들러를 지원합니다. Laravel에서는 이러한 핸들러를 손쉽게 설정하고, 여러 핸들러를 조합해 애플리케이션의 로그 처리 방식을 자유롭게 커스터마이징할 수 있습니다.
 
 <a name="configuration"></a>
+## 구성
 
-애플리케이션의 로깅 동작을 제어하는 모든 설정 옵션은 `config/logging.php` 설정 파일에 있습니다. 이 파일에서는 애플리케이션의 로그 채널을 설정할 수 있으므로, 사용 가능한 각 채널과 그 옵션을 꼭 확인하세요. 아래에서 몇 가지 일반적인 옵션을 살펴보겠습니다.
-### Available Channel Drivers
+애플리케이션의 로깅 동작을 제어하는 모든 설정은 `config/logging.php` 파일에 있습니다. 이 파일에서는 애플리케이션의 로그 채널을 설정할 수 있습니다. 각 채널과 그 옵션을 반드시 확인하세요. 주요 설정 옵션 몇 가지를 아래에서 살펴봅니다.
 
+기본적으로 Laravel은 로그 메시지 작성 시 `stack` 채널을 사용합니다. `stack` 채널은 여러 로그 채널을 하나로 묶어줍니다. 스택 구성에 대한 자세한 내용은 [아래 문서](#building-log-stacks)를 참고하세요.
 
+<a name="available-channel-drivers"></a>
+### 사용 가능한 채널 드라이버
+
+각 로그 채널은 "드라이버"에 의해 동작합니다. 드라이버는 로그 메시지가 실제로 어떻게, 어디에 기록될지 결정합니다. 아래의 로그 채널 드라이버는 모든 Laravel 애플리케이션에서 사용 가능합니다. 대부분의 드라이버는 애플리케이션의 `config/logging.php` 파일에 이미 설정되어 있으니 반드시 이 파일을 확인하세요.
 
 <div class="overflow-auto">
 
-기본적으로, Laravel은 메시지를 기록할 때 `stack` 채널을 사용합니다. `stack` 채널은 여러 로그 채널을 하나의 채널로 통합하는 데 사용됩니다. 스택을 구성하는 방법에 대한 자세한 내용은 [아래 문서](#building-log-stacks)를 참고하세요.
-
-<a name="available-channel-drivers"></a>
-각 로그 채널은 "driver"에 의해 구동됩니다. driver는 로그 메시지가 실제로 어떻게, 어디에 기록되는지를 결정합니다. 다음의 로그 채널 드라이버들은 모든 Laravel 애플리케이션에서 사용할 수 있습니다. 대부분의 드라이버에 대한 항목은 이미 애플리케이션의 `config/logging.php` 설정 파일에 있으므로, 이 파일을 확인하여 해당 내용을 숙지하시기 바랍니다:
-
-| Name         | Description                                                          |
-| ------------ | -------------------------------------------------------------------- |
-| `custom`     | 지정된 팩토리를 호출하여 채널을 생성하는 드라이버.                  |
-| `daily`      | 매일 회전되는 `RotatingFileHandler` 기반의 Monolog 드라이버.         |
-| `errorlog`   | `ErrorLogHandler` 기반의 Monolog 드라이버.                           |
-| `monolog`    | 지원되는 모든 Monolog 핸들러를 사용할 수 있는 Monolog 팩토리 드라이버. |
+| 이름         | 설명                                                                   |
+| ------------ | ---------------------------------------------------------------------- |
+| `custom`     | 지정된 팩토리를 호출해 채널을 생성하는 드라이버                        |
+| `daily`      | 하루 간격으로 로그 파일을 회전하는 `RotatingFileHandler` 기반 Monolog 드라이버 |
+| `errorlog`   | 시스템 에러 로그에 기록하는 `ErrorLogHandler` 기반 Monolog 드라이버     |
+| `monolog`    | 다양한 Monolog 핸들러를 사용할 수 있는 Monolog 팩토리 드라이버          |
+| `papertrail` | `SyslogUdpHandler` 기반 Monolog 드라이버                                |
+| `single`     | 하나의 파일 또는 경로에 기록하는 채널 (`StreamHandler`)                 |
+| `slack`      | `SlackWebhookHandler` 기반 Monolog 드라이버                             |
+| `stack`      | 여러 채널을 묶어 멀티채널을 만드는 래퍼                                |
+| `syslog`     | `SyslogHandler` 기반 Monolog 드라이버                                   |
 
 </div>
 
 > [!NOTE]
-| `papertrail` | `SyslogUdpHandler` 기반의 Monolog 드라이버.                          |
+> `monolog`와 `custom` 드라이버에 대한 자세한 내용은 [채널 커스터마이징 문서](#monolog-channel-customization)를 참고하세요.
 
-| `single`     | 단일 파일 또는 경로 기반의 로거 채널 (`StreamHandler`).              |
-#### Configuring the Channel Name
+<a name="configuring-the-channel-name"></a>
+#### 채널 이름 설정
 
-| `slack`      | `SlackWebhookHandler` 기반의 Monolog 드라이버.                       |
+기본적으로 Monolog은 현재 환경(`production`, `local` 등)과 일치하는 "채널 이름"을 사용합니다. 이 값을 변경하려면, 채널 설정에 `name` 옵션을 추가할 수 있습니다:
 
 ```php
 'stack' => [
@@ -71,50 +71,50 @@ Laravel의 로깅은 "채널(channels)"을 기반으로 합니다. 각 채널은
 ],
 ```
 
-| `stack`      | "멀티 채널" 채널을 만들 수 있도록 하는 래퍼.                        |
-### Channel Prerequisites
-
-| `syslog`     | `SyslogHandler` 기반의 Monolog 드라이버.                             |
-#### Configuring the Single and Daily Channels
-
-
-
-<div class="overflow-auto">
-
-> [advanced channel customization](#monolog-channel-customization)에 대한 문서를 확인하여 `monolog` 및 `custom` 드라이버에 대해 더 알아보세요.
-
-<a name="configuring-the-channel-name"></a>
-기본적으로, Monolog는 현재 환경(`production` 또는 `local` 등)과 일치하는 "채널 이름"으로 인스턴스화됩니다. 이 값을 변경하려면, 채널 설정에 `name` 옵션을 추가하면 됩니다:
-
-
-</div>
-
 <a name="channel-prerequisites"></a>
-
-<div class="overflow-auto">
+### 채널 사전 요구 사항
 
 <a name="configuring-the-single-and-daily-channels"></a>
-`single` 및 `daily` 채널에는 `bubble`, `permission`, `locking` 세 가지 선택적 설정 옵션이 있습니다.
+#### Single 및 Daily 채널 구성
 
+`single`과 `daily` 채널에는 `bubble`, `permission`, `locking`의 세 가지 옵션이 있습니다.
+
+<div class="overflow-auto">
+
+| 이름         | 설명                                                                 | 기본값   |
+| ------------ | -------------------------------------------------------------------- | ------- |
+| `bubble`     | 메시지 처리 후 다른 채널로도 메시지가 전파될지 여부                   | `true`  |
+| `locking`    | 로그 파일에 기록하기 전 파일을 잠글지 여부                            | `false` |
+| `permission` | 로그 파일의 권한                                                     | `0644`  |
 
 </div>
 
-| Name         | Description                                                                   | Default |
-#### Configuring the Papertrail Channel
+또한, `daily` 채널의 보존 일수는 `LOG_DAILY_DAYS` 환경변수 또는 `days` 옵션으로 설정할 수 있습니다.
 
-| ------------ | ----------------------------------------------------------------------------- | ------- |
+<div class="overflow-auto">
 
-| `bubble`     | 메시지가 처리된 후 다른 채널로 전달될지 여부를 나타냅니다.                   | `true`  |
-#### Configuring the Slack Channel
+| 이름     | 설명                              | 기본값 |
+| -------- | --------------------------------- | ------ |
+| `days`   | 일별 로그 파일의 보존 일수 지정    | `14`   |
 
-| `locking`    | 기록하기 전에 로그 파일을 잠그려고 시도합니다.                               | `false` |
+</div>
 
-| `permission` | 로그 파일의 권한을 설정합니다.                                                | `0644`  |
+<a name="configuring-the-papertrail-channel"></a>
+#### Papertrail 채널 설정
 
-Additionally, the retention policy for the `daily` channel can be configured via the `LOG_DAILY_DAYS` environment variable or by setting the `days` configuration option.  
-### Logging Deprecation Warnings
+`papertrail` 채널은 `host`와 `port` 설정이 필요합니다. 이 값들은 각자의 환경 변수 `PAPERTRAIL_URL`과 `PAPERTRAIL_PORT`로 지정할 수 있습니다. [Papertrail](https://help.papertrailapp.com/kb/configuration/configuring-centralized-logging-from-php-apps/#send-events-from-php-app)에서 제공하는 값을 사용하세요.
 
-| Name   | Description                                                 | Default |
+<a name="configuring-the-slack-channel"></a>
+#### Slack 채널 설정
+
+`slack` 채널은 `url` 설정이 필수입니다. 이 값은 `LOG_SLACK_WEBHOOK_URL` 환경 변수로 지정할 수 있습니다. 이 URL은 Slack 팀에 대해 구성한 [incoming webhook](https://slack.com/apps/A0F7XDUAZ-incoming-webhooks)의 URL이어야 합니다.
+
+기본적으로 Slack은 `critical` 레벨 이상의 로그만 받습니다. 이 동작은 `LOG_LEVEL` 환경 변수나 Slack 로그 채널 배열의 `level` 옵션으로 조정할 수 있습니다.
+
+<a name="logging-deprecation-warnings"></a>
+### 폐기 예정 경고 로깅
+
+PHP, Laravel 및 기타 라이브러리는 사용 중인 일부 기능이 폐기(deprecated)되어 향후 버전에서 제거될 것임을 경고합니다. 이러한 폐기 경고를 로그로 남기고 싶다면, `LOG_DEPRECATIONS_CHANNEL` 환경 변수 또는 애플리케이션의 `config/logging.php`에서 원하는 `deprecations` 로그 채널을 지정할 수 있습니다:
 
 ```php
 'deprecations' => [
@@ -127,7 +127,7 @@ Additionally, the retention policy for the `daily` channel can be configured via
 ]
 ```
 
-| ------ | ----------------------------------------------------------- | ------- |
+또는, `deprecations`라는 이름의 로그 채널을 직접 정의할 수도 있습니다. 이 경우 해당 채널이 항상 폐기 경고를 기록합니다:
 
 ```php
 'channels' => [
@@ -138,10 +138,10 @@ Additionally, the retention policy for the `daily` channel can be configured via
 ],
 ```
 
-| `days` | 매일 로그 파일을 얼마나 오래(일 수) 보관할지 설정합니다.                 | `14`    |
-## Building Log Stacks
+<a name="building-log-stacks"></a>
+## Log 스택 빌드
 
-
+앞서 언급했듯이, `stack` 드라이버를 사용하면 여러 채널을 하나의 스택으로 묶어 로그를 처리할 수 있습니다. 아래는 실제 운영 환경에서 볼 수 있는 Stack 구성 예시입니다:
 
 ```php
 'channels' => [
@@ -169,29 +169,29 @@ Additionally, the retention policy for the `daily` channel can be configured via
 ],
 ```
 
-<a name="configuring-the-papertrail-channel"></a>
+이 설정을 분석해보면, `stack` 채널은 `channels` 옵션을 통해 `syslog`와 `slack`이라는 두 채널을 묶고 있습니다. 따라서 로그 메시지를 기록할 때, 두 채널 모두 메시지를 기록할 기회를 갖습니다. 하지만 실제로 메시지를 기록하는지는 각 채널의 심각도(레벨)에 따라 달라집니다.
 
-The `papertrail` channel requires `host` and `port` configuration options. These may be defined via the `PAPERTRAIL_URL` and `PAPERTRAIL_PORT` environment variables. You can obtain these values from [Papertrail](https://help.papertrailapp.com/kb/configuration/configuring-centralized-logging-from-php-apps/#send-events-from-php-app).
-#### Log Levels
+<a name="log-levels"></a>
+#### 로그 레벨
 
+위 예시의 `syslog`와 `slack` 설정에서 `level` 옵션에 주목하세요. 이 옵션은 해당 채널이 로그를 기록하기 위한 최소 "레벨"을 지정합니다. Laravel의 로깅 서비스 기반인 Monolog은 [RFC 5424 사양](https://tools.ietf.org/html/rfc5424)에 정의된 모든 로그 레벨을 지원합니다. 심각도 순서대로: **emergency**, **alert**, **critical**, **error**, **warning**, **notice**, **info**, **debug** 입니다.
 
-
-<a name="configuring-the-slack-channel"></a>
+예를 들어, 아래처럼 `debug` 레벨로 로그를 작성하면:
 
 ```php
 Log::debug('An informational message.');
 ```
 
-The `slack` channel requires a `url` configuration option. This value may be defined via the `LOG_SLACK_WEBHOOK_URL` environment variable. This URL should match a URL for an [incoming webhook](https://slack.com/apps/A0F7XDUAZ-incoming-webhooks) that you have configured for your Slack team.  
+이 구성에서는 `syslog` 채널이 시스템 로그에 메시지를 기록합니다. 하지만 해당 메시지는 `critical` 이상이 아니므로 Slack으로는 전송되지 않습니다. 반면, `emergency` 레벨 메시지는 시스템 로그와 Slack 모두에 기록됩니다. (해당 레벨이 두 채널의 최소 심각도 기준을 충족하기 때문입니다.)
 
 ```php
 Log::emergency('The system is down!');
 ```
 
-By default, Slack will only receive logs at the `critical` level and above; however, you can adjust this using the `LOG_LEVEL` environment variable or by modifying the `level` configuration option within your Slack log channel's configuration array.
-## Writing Log Messages
+<a name="writing-log-messages"></a>
+## 로그 메시지 작성
 
-
+로그를 작성하려면 `Log` [파사드](/docs/{{version}}/facades)를 사용할 수 있습니다. 앞서 언급했듯이, 로거는 [RFC 5424 사양](https://tools.ietf.org/html/rfc5424)에 정의된 8개의 로그 레벨 메서드를 제공합니다: **emergency**, **alert**, **critical**, **error**, **warning**, **notice**, **info**, **debug**.
 
 ```php
 use Illuminate\Support\Facades\Log;
@@ -206,7 +206,7 @@ Log::info($message);
 Log::debug($message);
 ```
 
-<a name="logging-deprecation-warnings"></a>
+이들 메서드 중 아무거나 호출하면 해당 레벨로 로그가 작성됩니다. 기본적으로는 `logging` 설정 파일에서 지정한 기본 로그 채널에 메시지가 기록됩니다:
 
 ```php
 <?php
@@ -220,7 +220,7 @@ use Illuminate\View\View;
 class UserController extends Controller
 {
     /**
-     * Show the profile for the given user.
+     * 주어진 사용자의 프로필을 보여줍니다.
      */
     public function show(string $id): View
     {
@@ -233,10 +233,10 @@ class UserController extends Controller
 }
 ```
 
-PHP, Laravel, and other libraries often notify their users that some of their features have been deprecated and will be removed in a future version. If you would like to log these deprecation warnings, you may specify your preferred `deprecations` log channel using the `LOG_DEPRECATIONS_CHANNEL` environment variable, or within your application's `config/logging.php` configuration file:  
-### Contextual Information
+<a name="contextual-information"></a>
+### 컨텍스트 정보
 
-Or, you may define a log channel named `deprecations`. If a log channel with this name exists, it will always be used to log deprecations:
+로그 메서드에는 컨텍스트 데이터 배열을 추가로 전달할 수 있습니다. 이 데이터는 로그 메시지와 함께 포맷되어 출력됩니다:
 
 ```php
 use Illuminate\Support\Facades\Log;
@@ -244,7 +244,7 @@ use Illuminate\Support\Facades\Log;
 Log::info('User {id} failed to login.', ['id' => $user->id]);
 ```
 
-
+특정 요청에서 모든 다음 로그에 포함될 컨텍스트 정보를 추가하고 싶을 때도 있습니다. 예를 들어, 각 요청에 대한 고유 요청 ID 등을 남기고 싶을 때는, `Log` 파사드의 `withContext` 메서드를 사용할 수 있습니다:
 
 ```php
 <?php
@@ -260,7 +260,7 @@ use Symfony\Component\HttpFoundation\Response;
 class AssignRequestId
 {
     /**
-     * Handle an incoming request.
+     * 들어오는 요청을 처리합니다.
      *
      * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
      */
@@ -281,7 +281,7 @@ class AssignRequestId
 }
 ```
 
-<a name="building-log-stacks"></a>
+_모든_ 로깅 채널에 걸쳐서 컨텍스트 정보를 공유하고 싶다면, `Log::shareContext()` 메서드를 사용할 수 있습니다. 이 메서드는 이미 생성된 채널과 앞으로 생성될 모든 채널에 컨텍스트 정보를 제공합니다.
 
 ```php
 <?php
@@ -297,7 +297,7 @@ use Symfony\Component\HttpFoundation\Response;
 class AssignRequestId
 {
     /**
-     * Handle an incoming request.
+     * 들어오는 요청을 처리합니다.
      *
      * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
      */
@@ -315,12 +315,12 @@ class AssignRequestId
 ```
 
 > [!NOTE]
-As mentioned previously, the `stack` driver allows you to combine multiple channels into a single log channel for convenience. To illustrate how to use log stacks, let's take a look at an example configuration that you might see in a production application:  
+> 큐 처리 중 로그 컨텍스트를 공유하려면 [잡 미들웨어](/docs/{{version}}/queues#job-middleware)를 사용할 수 있습니다.
 
-Let's dissect this configuration. First, notice our `stack` channel aggregates two other channels via its `channels` option: `syslog` and `slack`. So, when logging messages, both of these channels will have the opportunity to log the message. However, as we will see below, whether these channels actually log the message may be determined by the message's severity / "level".
-### Writing to Specific Channels
+<a name="writing-to-specific-channels"></a>
+### 특정 채널로 로깅하기
 
-
+기본 채널이 아닌 특정 채널에 로그를 남기고 싶을 때가 있습니다. `Log` 파사드의 `channel` 메서드를 사용하면 설정 파일에 정의된 임의의 채널로 접근해 로그를 남길 수 있습니다:
 
 ```php
 use Illuminate\Support\Facades\Log;
@@ -328,16 +328,16 @@ use Illuminate\Support\Facades\Log;
 Log::channel('slack')->info('Something happened!');
 ```
 
-<a name="log-levels"></a>
+복수 채널로 이뤄진 임시 스택을 만들고 싶다면, `stack` 메서드를 사용할 수 있습니다.
 
 ```php
 Log::stack(['single', 'slack'])->info('Something happened!');
 ```
 
-Take note of the `level` configuration option present on the `syslog` and `slack` channel configurations in the example above. This option determines the minimum "level" a message must be in order to be logged by the channel. Monolog, which powers Laravel's logging services, offers all of the log levels defined in the [RFC 5424 specification](https://tools.ietf.org/html/rfc5424). In descending order of severity, these log levels are: **emergency**, **alert**, **critical**, **error**, **warning**, **notice**, **info**, and **debug**.
-#### On-Demand Channels
+<a name="on-demand-channels"></a>
+#### On-Demand 채널
 
-
+애플리케이션의 `logging` 설정 파일에 미리 정의하지 않은 임시 채널을 동적으로 생성하고 싶을 때, 런타임에 설정 배열을 `Log` 파사드의 `build` 메서드로 전달하면 됩니다:
 
 ```php
 use Illuminate\Support\Facades\Log;
@@ -348,7 +348,7 @@ Log::build([
 ])->info('Something happened!');
 ```
 
-So, imagine we log a message using the `debug` method:
+임시(on-demand) 채널을 임시 스택에 포함시키는 것도 가능합니다. 이때는 인스턴스를 `stack` 메서드에 배열로 전달하면 됩니다:
 
 ```php
 use Illuminate\Support\Facades\Log;
@@ -361,15 +361,15 @@ $channel = Log::build([
 Log::stack(['slack', $channel])->info('Something happened!');
 ```
 
-Given our configuration, the `syslog` channel will write the message to the system log; however, since the error message is not `critical` or above, it will not be sent to Slack. However, if we log an `emergency` message, it will be sent to both the system log and Slack since the `emergency` level is above our minimum level threshold for both channels:
-## Monolog Channel Customization
+<a name="monolog-channel-customization"></a>
+## Monolog 채널 커스터마이징
 
+<a name="customizing-monolog-for-channels"></a>
+### 채널별 Monolog 커스터마이징
 
-### Customizing Monolog for Channels
+기존 채널에 대해 Monolog의 동작을 완전히 제어해야 하는 경우가 있습니다. 예를 들어, Laravel의 내장 `single` 채널에 사용자 지정 Monolog `FormatterInterface` 구현체를 적용하려는 경우입니다.
 
-<a name="writing-log-messages"></a>
-
-You may write information to the logs using the `Log` [facade](/docs/{{version}}/facades). As previously mentioned, the logger provides the eight logging levels defined in the [RFC 5424 specification](https://tools.ietf.org/html/rfc5424): **emergency**, **alert**, **critical**, **error**, **warning**, **notice**, **info** and **debug**:
+우선, 채널 설정에 `tap` 배열을 정의하세요. `tap` 배열은 Monolog 인스턴스가 생성된 후 커스터마이징(또는 "탭")할 수 있는 클래스 리스트입니다. 이 클래스는 원하시는 곳(예: `App\Logging`)에 두셔도 됩니다.
 
 ```php
 'single' => [
@@ -381,7 +381,7 @@ You may write information to the logs using the `Log` [facade](/docs/{{version}}
 ],
 ```
 
-다음은 원문을 ko로 번역한 내용입니다(코드, 링크, 마크다운 구문은 그대로 유지):
+`tap` 옵션을 설정했다면, 이제 실제 Monolog 인스턴스를 커스터마이징하는 클래스를 만듭니다. 이 클래스는 `__invoke`라는 메서드 하나만 필요하며, 인자로 `Illuminate\Log\Logger` 인스턴스를 받습니다. 이 인스턴스는 내부적으로 모든 호출을 Monolog 인스턴스로 위임합니다.
 
 ```php
 <?php
@@ -394,7 +394,7 @@ use Monolog\Formatter\LineFormatter;
 class CustomizeFormatter
 {
     /**
-     * Customize the given logger instance.
+     * 주어진 로거 인스턴스를 커스터마이징합니다.
      */
     public function __invoke(Logger $logger): void
     {
@@ -408,14 +408,14 @@ class CustomizeFormatter
 ```
 
 > [!NOTE]
+> 모든 `tap` 클래스는 [서비스 컨테이너](/docs/{{version}}/container)에서 해석되므로, 생성자에 의존성이 있더라도 자동으로 주입됩니다.
 
+<a name="creating-monolog-handler-channels"></a>
+### Monolog 핸들러 채널 생성
 
-You may call any of these methods to log a message for the corresponding level. By default, the message will be written to the default log channel as configured by your `logging` configuration file:
-### Creating Monolog Handler Channels
+Monolog에는 [다양한 핸들러](https://github.com/Seldaek/monolog/tree/main/src/Monolog/Handler)가 있지만, Laravel은 모든 핸들러용 빌트인 채널을 포함하진 않습니다. 특정 핸들러만 사용하는 커스텀 채널이 필요하다면, `monolog` 드라이버를 사용해 쉽게 만들 수 있습니다.
 
-<a name="contextual-information"></a>
-
-로그 메서드에 컨텍스트 데이터 배열을 전달할 수 있습니다. 이 컨텍스트 데이터는 로그 메시지와 함께 포맷팅되어 표시됩니다:
+`monolog` 드라이버를 사용할 때는 어느 핸들러를 사용할지 `handler` 설정에 지정합니다. 필요한 핸들러 생성자 인자는 `handler_with` 배열에 지정하세요:
 
 ```php
 'logentries' => [
@@ -428,10 +428,10 @@ You may call any of these methods to log a message for the corresponding level. 
 ],
 ```
 
-가끔, 이후에 기록되는 모든 로그 항목에 포함되어야 하는 컨텍스트 정보를 지정하고 싶을 때가 있을 수 있습니다. 예를 들어, 애플리케이션으로 들어오는 각 요청과 연관된 요청 ID를 로깅하고 싶을 수 있습니다. 이를 위해서는 `Log` 퍼사드의 `withContext` 메서드를 호출하면 됩니다:
-#### Monolog Formatters
+<a name="monolog-formatters"></a>
+#### Monolog 포매터
 
-모든 로깅 채널에 걸쳐 컨텍스트 정보를 공유하고 싶다면, `Log::shareContext()` 메서드를 호출할 수 있습니다. 이 메서드는 이미 생성된 모든 채널 및 이후에 생성되는 모든 채널에 컨텍스트 정보를 제공합니다:
+`monolog` 드라이버를 사용하면 Monolog의 `LineFormatter`가 기본 사용됩니다. 핸들러에 넘길 포매터 타입을 바꾸고 싶다면 `formatter`와 `formatter_with` 옵션을 이용하세요:
 
 ```php
 'browser' => [
@@ -444,7 +444,7 @@ You may call any of these methods to log a message for the corresponding level. 
 ],
 ```
 
-> 큐에 적재된 작업을 처리하면서 로그 컨텍스트를 공유해야 할 경우, [job middleware](/docs/{{version}}/queues#job-middleware)를 활용할 수 있습니다.
+핸들러 자체가 자체 포매터를 제공하는 경우, `formatter` 값을 `default`로 지정하면 핸들러 기본 포매터가 사용됩니다.
 
 ```php
 'newrelic' => [
@@ -454,12 +454,12 @@ You may call any of these methods to log a message for the corresponding level. 
 ],
 ```
 
+<a name="monolog-processors"></a>
+#### Monolog 프로세서
 
-#### Monolog Processors
+Monolog은 로그 기록 전에 메시지를 처리하는 프로세서를 사용할 수 있습니다. 직접 프로세서를 만들거나, Monolog에서 제공하는 [기존 프로세서](https://github.com/Seldaek/monolog/tree/main/src/Monolog/Processor)를 사용할 수 있습니다.
 
-<a name="writing-to-specific-channels"></a>
-
-때로는 애플리케이션의 기본 채널이 아닌 다른 채널에 메시지를 기록하고자 할 수 있습니다. 이 경우 `Log` 퍼사드의 `channel` 메서드를 사용하여 구성 파일에 정의된 어떤 채널이든 가져와서 로그를 기록할 수 있습니다:
+`monolog` 드라이버에서 프로세서를 커스터마이징하려면, 채널 설정에 `processors` 값을 배열로 추가하세요:
 
 ```php
 'memory' => [
@@ -469,10 +469,10 @@ You may call any of these methods to log a message for the corresponding level. 
         'stream' => 'php://stderr',
     ],
     'processors' => [
-        // Simple syntax...
+        // 단순히 클래스명만...
         Monolog\Processor\MemoryUsageProcessor::class,
 
-        // With options...
+        // 옵션과 함께...
         [
             'processor' => Monolog\Processor\PsrLogMessageProcessor::class,
             'with' => ['removeUsedContextFields' => true],
@@ -481,10 +481,10 @@ You may call any of these methods to log a message for the corresponding level. 
 ],
 ```
 
-여러 채널로 구성된 온디맨드 로깅 스택을 생성하고 싶다면, `stack` 메서드를 사용할 수 있습니다:
-### Creating Custom Channels via Factories
+<a name="creating-custom-channels-via-factories"></a>
+### 팩토리를 통한 커스텀 채널 생성
 
-
+Monolog 인스턴스의 생성 및 구성을 완전히 제어하고 싶은 경우, `config/logging.php` 설정 파일에서 `custom` 드라이버 타입을 지정할 수 있습니다. 이때 `via` 옵션에 Monolog 인스턴스를 생성하는 팩토리 클래스명을 지정해야 합니다:
 
 ```php
 'channels' => [
@@ -495,7 +495,7 @@ You may call any of these methods to log a message for the corresponding level. 
 ],
 ```
 
-<a name="on-demand-channels"></a>
+이제 `custom` 드라이버 채널에 실제 Monolog 인스턴스를 반환하는 클래스의 `__invoke` 메서드만 구현하면 됩니다. 이 메서드는 채널 설정 배열을 인자로 받습니다.
 
 ```php
 <?php
@@ -507,7 +507,7 @@ use Monolog\Logger;
 class CreateCustomLogger
 {
     /**
-     * Create a custom Monolog instance.
+     * 커스텀 Monolog 인스턴스를 생성합니다.
      */
     public function __invoke(array $config): Logger
     {
@@ -516,84 +516,84 @@ class CreateCustomLogger
 }
 ```
 
-애플리케이션의 `logging` 구성 파일에 없는 설정을 런타임에 제공함으로써 온디맨드 채널을 생성할 수도 있습니다. 이를 위해 `Log` 퍼사드의 `build` 메서드에 구성 배열을 전달하면 됩니다:
-## Tailing Log Messages Using Pail
+<a name="tailing-log-messages-using-pail"></a>
+## Pail을 사용한 로그 테일링
 
-온디맨드 로깅 스택에 온디맨드 채널을 포함하고 싶을 수도 있습니다. 이를 위해서는 온디맨드 채널 인스턴스를 `stack` 메서드에 전달되는 배열에 포함하면 됩니다:
+실시간으로 애플리케이션 로그를 모니터링해야 할 때가 있습니다. 예를 들어 문제를 디버깅하거나 특정 에러 유형을 모니터링할 때가 그러합니다.
 
-
+Laravel Pail은 커맨드 라인에서 바로 Laravel 애플리케이션의 로그 파일을 손쉽게 따라갈 수 있는 패키지입니다. 표준 `tail` 명령과 달리, Pail은 Sentry나 Flare 등 외부 로그 드라이버와도 연동됩니다. 또한, 유용한 필터 기능으로 원하는 로그만 빠르게 찾을 수 있습니다.
 
 <img src="https://laravel.com/img/docs/pail-example.png">
 
-<a name="monolog-channel-customization"></a>
-### Installation
+<a name="pail-installation"></a>
+### 설치
 
 > [!WARNING]
-<a name="customizing-monolog-for-channels"></a>
+> Laravel Pail은 [PHP 8.2+](https://php.net/releases/) 및 [PCNTL](https://www.php.net/manual/en/book.pcntl.php) 확장이 필요합니다.
 
-기존 채널에 대해 Monolog의 구성 방식을 완전히 제어해야 하는 경우가 있을 수 있습니다. 예를 들어, Laravel에 내장된 `single` 채널에 대해 사용자 정의 Monolog `FormatterInterface` 구현을 설정하고 싶을 수 있습니다.
+먼저 Composer 패키지 매니저로 Pail을 설치하세요:
 
 ```shell
 composer require laravel/pail
 ```
 
-먼저, 채널의 구성에서 `tap` 배열을 정의합니다. `tap` 배열은 Monolog 인스턴스가 생성된 후 이를 커스터마이즈(또는 '탭')할 수 있는 클래스들의 목록을 포함해야 합니다. 이 클래스들이 위치해야 할 전통적인 디렉터리는 없으므로, 애플리케이션 내에서 새로운 디렉터리를 만들어 자유롭게 저장할 수 있습니다:
-### Usage
+<a name="pail-usage"></a>
+### 사용법
 
-채널에서 `tap` 옵션을 설정한 뒤, 이제 Monolog 인스턴스를 커스터마이즈할 클래스를 정의할 수 있습니다. 이 클래스에는 단 하나의 메서드, 즉 `__invoke`만 필요하며, 이 메서드는 `Illuminate\Log\Logger` 인스턴스를 전달받습니다. `Illuminate\Log\Logger` 인스턴스는 내부의 Monolog 인스턴스에 모든 메서드 호출을 프록싱합니다:
+로그 테일링을 시작하려면 다음 명령어를 입력하세요:
 
 ```shell
 php artisan pail
 ```
 
-> 모든 'tap' 클래스는 [service container](/docs/{{version}}/container)에 의해 해석되므로, 필요한 생성자 종속성이 자동으로 주입됩니다.
+출력의 상세 수준을 높이고 로그 메시지 컷팅(…)을 방지하려면 `-v` 옵션을 사용하면 됩니다:
 
 ```shell
 php artisan pail -v
 ```
 
-
+최대 상세 수준 및 예외 스택 트레이스까지 보려면 `-vv` 옵션을 사용하세요:
 
 ```shell
 php artisan pail -vv
 ```
 
-<a name="creating-monolog-handler-channels"></a>
+로그 테일링을 중지하려면 언제든 `Ctrl+C`를 누르세요.
 
-Monolog에는 [사용 가능한 다양한 핸들러들](https://github.com/Seldaek/monolog/tree/main/src/Monolog/Handler)이 있으며, Laravel은 각각에 대한 빌트인 채널을 제공하지 않습니다. 경우에 따라, 특정 Monolog 핸들러에 해당하는 별도의 Laravel 로그 드라이버가 없을 때, 그 인스턴스만을 사용하는 커스텀 채널을 만들고 싶을 수 있습니다. 이러한 채널은 `monolog` 드라이버를 사용하여 손쉽게 생성할 수 있습니다.
-### Filtering Logs
+<a name="pail-filtering-logs"></a>
+### 로그 필터링
 
-`monolog` 드라이버를 사용할 때, `handler` 구성 옵션을 통해 어떤 핸들러가 인스턴스화될지를 지정합니다. 선택적으로, 핸들러가 필요로 하는 생성자 파라미터는 `handler_with` 구성 옵션을 사용하여 지정할 수 있습니다:
+<a name="pail-filtering-logs-filter-option"></a>
 #### `--filter`
 
-
+`--filter` 옵션으로 로그 타입, 파일명, 메시지, 스택 트레이스 내용을 기준으로 로그를 필터할 수 있습니다:
 
 ```shell
 php artisan pail --filter="QueryException"
 ```
 
-<a name="monolog-formatters"></a>
+<a name="pail-filtering-logs-message-option"></a>
 #### `--message`
 
-`monolog` 드라이버를 사용할 때, 기본 포매터로 Monolog `LineFormatter`가 사용됩니다. 그러나 `formatter` 및 `formatter_with` 구성 옵션을 사용하여 핸들러에 전달되는 포매터 유형을 커스터마이징할 수 있습니다:
+오직 로그 메시지만을 기준으로 필터링하려면 `--message` 옵션을 사용하세요:
 
 ```shell
 php artisan pail --message="User created"
 ```
 
-
+<a name="pail-filtering-logs-level-option"></a>
 #### `--level`
 
-Monolog 핸들러가 자체 포매터를 제공할 수 있는 경우, `formatter` 구성 옵션의 값을 `default`로 설정할 수 있습니다:
+`--level` 옵션으로 [로그 레벨](#log-levels)에 따라 필터링할 수 있습니다:
 
 ```shell
 php artisan pail --level=error
 ```
 
-
+<a name="pail-filtering-logs-user-option"></a>
 #### `--user`
 
-<a name="monolog-processors"></a>
+특정 사용자가 인증된 상태에서 작성된 로그만 표시하려면 사용자 ID를 `--user` 옵션에 지정하세요:
 
 ```shell
 php artisan pail --user=1

--- a/sample/logging.md
+++ b/sample/logging.md
@@ -1,0 +1,600 @@
+# Logging
+
+- [Introduction](#introduction)
+- [Configuration](#configuration)
+    - [Available Channel Drivers](#available-channel-drivers)
+    - [Channel Prerequisites](#channel-prerequisites)
+    - [Logging Deprecation Warnings](#logging-deprecation-warnings)
+- [Building Log Stacks](#building-log-stacks)
+- [Writing Log Messages](#writing-log-messages)
+    - [Contextual Information](#contextual-information)
+    - [Writing to Specific Channels](#writing-to-specific-channels)
+- [Monolog Channel Customization](#monolog-channel-customization)
+    - [Customizing Monolog for Channels](#customizing-monolog-for-channels)
+    - [Creating Monolog Handler Channels](#creating-monolog-handler-channels)
+    - [Creating Custom Channels via Factories](#creating-custom-channels-via-factories)
+- [Tailing Log Messages Using Pail](#tailing-log-messages-using-pail)
+    - [Installation](#pail-installation)
+    - [Usage](#pail-usage)
+    - [Filtering Logs](#pail-filtering-logs)
+
+<a name="introduction"></a>
+## Introduction
+
+To help you learn more about what's happening within your application, Laravel provides robust logging services that allow you to log messages to files, the system error log, and even to Slack to notify your entire team.
+
+Laravel logging is based on "channels". Each channel represents a specific way of writing log information. For example, the `single` channel writes log files to a single log file, while the `slack` channel sends log messages to Slack. Log messages may be written to multiple channels based on their severity.
+
+Under the hood, Laravel utilizes the [Monolog](https://github.com/Seldaek/monolog) library, which provides support for a variety of powerful log handlers. Laravel makes it a cinch to configure these handlers, allowing you to mix and match them to customize your application's log handling.
+
+<a name="configuration"></a>
+## Configuration
+
+All of the configuration options that control your application's logging behavior are housed in the `config/logging.php` configuration file. This file allows you to configure your application's log channels, so be sure to review each of the available channels and their options. We'll review a few common options below.
+
+By default, Laravel will use the `stack` channel when logging messages. The `stack` channel is used to aggregate multiple log channels into a single channel. For more information on building stacks, check out the [documentation below](#building-log-stacks).
+
+<a name="available-channel-drivers"></a>
+### Available Channel Drivers
+
+Each log channel is powered by a "driver". The driver determines how and where the log message is actually recorded. The following log channel drivers are available in every Laravel application. An entry for most of these drivers is already present in your application's `config/logging.php` configuration file, so be sure to review this file to become familiar with its contents:
+
+<div class="overflow-auto">
+
+| Name         | Description                                                          |
+| ------------ | -------------------------------------------------------------------- |
+| `custom`     | A driver that calls a specified factory to create a channel.         |
+| `daily`      | A `RotatingFileHandler` based Monolog driver which rotates daily.    |
+| `errorlog`   | An `ErrorLogHandler` based Monolog driver.                           |
+| `monolog`    | A Monolog factory driver that may use any supported Monolog handler. |
+| `papertrail` | A `SyslogUdpHandler` based Monolog driver.                           |
+| `single`     | A single file or path based logger channel (`StreamHandler`).        |
+| `slack`      | A `SlackWebhookHandler` based Monolog driver.                        |
+| `stack`      | A wrapper to facilitate creating "multi-channel" channels.           |
+| `syslog`     | A `SyslogHandler` based Monolog driver.                              |
+
+</div>
+
+> [!NOTE]
+> Check out the documentation on [advanced channel customization](#monolog-channel-customization) to learn more about the `monolog` and `custom` drivers.
+
+<a name="configuring-the-channel-name"></a>
+#### Configuring the Channel Name
+
+By default, Monolog is instantiated with a "channel name" that matches the current environment, such as `production` or `local`. To change this value, you may add a `name` option to your channel's configuration:
+
+```php
+'stack' => [
+    'driver' => 'stack',
+    'name' => 'channel-name',
+    'channels' => ['single', 'slack'],
+],
+```
+
+<a name="channel-prerequisites"></a>
+### Channel Prerequisites
+
+<a name="configuring-the-single-and-daily-channels"></a>
+#### Configuring the Single and Daily Channels
+
+The `single` and `daily` channels have three optional configuration options: `bubble`, `permission`, and `locking`.
+
+<div class="overflow-auto">
+
+| Name         | Description                                                                   | Default |
+| ------------ | ----------------------------------------------------------------------------- | ------- |
+| `bubble`     | Indicates if messages should bubble up to other channels after being handled. | `true`  |
+| `locking`    | Attempt to lock the log file before writing to it.                            | `false` |
+| `permission` | The log file's permissions.                                                   | `0644`  |
+
+</div>
+
+Additionally, the retention policy for the `daily` channel can be configured via the `LOG_DAILY_DAYS` environment variable or by setting the `days` configuration option.
+
+<div class="overflow-auto">
+
+| Name   | Description                                                 | Default |
+| ------ | ----------------------------------------------------------- | ------- |
+| `days` | The number of days that daily log files should be retained. | `14`    |
+
+</div>
+
+<a name="configuring-the-papertrail-channel"></a>
+#### Configuring the Papertrail Channel
+
+The `papertrail` channel requires `host` and `port` configuration options. These may be defined via the `PAPERTRAIL_URL` and `PAPERTRAIL_PORT` environment variables. You can obtain these values from [Papertrail](https://help.papertrailapp.com/kb/configuration/configuring-centralized-logging-from-php-apps/#send-events-from-php-app).
+
+<a name="configuring-the-slack-channel"></a>
+#### Configuring the Slack Channel
+
+The `slack` channel requires a `url` configuration option. This value may be defined via the `LOG_SLACK_WEBHOOK_URL` environment variable. This URL should match a URL for an [incoming webhook](https://slack.com/apps/A0F7XDUAZ-incoming-webhooks) that you have configured for your Slack team.
+
+By default, Slack will only receive logs at the `critical` level and above; however, you can adjust this using the `LOG_LEVEL` environment variable or by modifying the `level` configuration option within your Slack log channel's configuration array.
+
+<a name="logging-deprecation-warnings"></a>
+### Logging Deprecation Warnings
+
+PHP, Laravel, and other libraries often notify their users that some of their features have been deprecated and will be removed in a future version. If you would like to log these deprecation warnings, you may specify your preferred `deprecations` log channel using the `LOG_DEPRECATIONS_CHANNEL` environment variable, or within your application's `config/logging.php` configuration file:
+
+```php
+'deprecations' => [
+    'channel' => env('LOG_DEPRECATIONS_CHANNEL', 'null'),
+    'trace' => env('LOG_DEPRECATIONS_TRACE', false),
+],
+
+'channels' => [
+    // ...
+]
+```
+
+Or, you may define a log channel named `deprecations`. If a log channel with this name exists, it will always be used to log deprecations:
+
+```php
+'channels' => [
+    'deprecations' => [
+        'driver' => 'single',
+        'path' => storage_path('logs/php-deprecation-warnings.log'),
+    ],
+],
+```
+
+<a name="building-log-stacks"></a>
+## Building Log Stacks
+
+As mentioned previously, the `stack` driver allows you to combine multiple channels into a single log channel for convenience. To illustrate how to use log stacks, let's take a look at an example configuration that you might see in a production application:
+
+```php
+'channels' => [
+    'stack' => [
+        'driver' => 'stack',
+        'channels' => ['syslog', 'slack'], // [tl! add]
+        'ignore_exceptions' => false,
+    ],
+
+    'syslog' => [
+        'driver' => 'syslog',
+        'level' => env('LOG_LEVEL', 'debug'),
+        'facility' => env('LOG_SYSLOG_FACILITY', LOG_USER),
+        'replace_placeholders' => true,
+    ],
+
+    'slack' => [
+        'driver' => 'slack',
+        'url' => env('LOG_SLACK_WEBHOOK_URL'),
+        'username' => env('LOG_SLACK_USERNAME', 'Laravel Log'),
+        'emoji' => env('LOG_SLACK_EMOJI', ':boom:'),
+        'level' => env('LOG_LEVEL', 'critical'),
+        'replace_placeholders' => true,
+    ],
+],
+```
+
+Let's dissect this configuration. First, notice our `stack` channel aggregates two other channels via its `channels` option: `syslog` and `slack`. So, when logging messages, both of these channels will have the opportunity to log the message. However, as we will see below, whether these channels actually log the message may be determined by the message's severity / "level".
+
+<a name="log-levels"></a>
+#### Log Levels
+
+Take note of the `level` configuration option present on the `syslog` and `slack` channel configurations in the example above. This option determines the minimum "level" a message must be in order to be logged by the channel. Monolog, which powers Laravel's logging services, offers all of the log levels defined in the [RFC 5424 specification](https://tools.ietf.org/html/rfc5424). In descending order of severity, these log levels are: **emergency**, **alert**, **critical**, **error**, **warning**, **notice**, **info**, and **debug**.
+
+So, imagine we log a message using the `debug` method:
+
+```php
+Log::debug('An informational message.');
+```
+
+Given our configuration, the `syslog` channel will write the message to the system log; however, since the error message is not `critical` or above, it will not be sent to Slack. However, if we log an `emergency` message, it will be sent to both the system log and Slack since the `emergency` level is above our minimum level threshold for both channels:
+
+```php
+Log::emergency('The system is down!');
+```
+
+<a name="writing-log-messages"></a>
+## Writing Log Messages
+
+You may write information to the logs using the `Log` [facade](/docs/{{version}}/facades). As previously mentioned, the logger provides the eight logging levels defined in the [RFC 5424 specification](https://tools.ietf.org/html/rfc5424): **emergency**, **alert**, **critical**, **error**, **warning**, **notice**, **info** and **debug**:
+
+```php
+use Illuminate\Support\Facades\Log;
+
+Log::emergency($message);
+Log::alert($message);
+Log::critical($message);
+Log::error($message);
+Log::warning($message);
+Log::notice($message);
+Log::info($message);
+Log::debug($message);
+```
+
+You may call any of these methods to log a message for the corresponding level. By default, the message will be written to the default log channel as configured by your `logging` configuration file:
+
+```php
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Log;
+use Illuminate\View\View;
+
+class UserController extends Controller
+{
+    /**
+     * Show the profile for the given user.
+     */
+    public function show(string $id): View
+    {
+        Log::info('Showing the user profile for user: {id}', ['id' => $id]);
+
+        return view('user.profile', [
+            'user' => User::findOrFail($id)
+        ]);
+    }
+}
+```
+
+<a name="contextual-information"></a>
+### Contextual Information
+
+An array of contextual data may be passed to the log methods. This contextual data will be formatted and displayed with the log message:
+
+```php
+use Illuminate\Support\Facades\Log;
+
+Log::info('User {id} failed to login.', ['id' => $user->id]);
+```
+
+Occasionally, you may wish to specify some contextual information that should be included with all subsequent log entries in a particular channel. For example, you may wish to log a request ID that is associated with each incoming request to your application. To accomplish this, you may call the `Log` facade's `withContext` method:
+
+```php
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\Response;
+
+class AssignRequestId
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $requestId = (string) Str::uuid();
+
+        Log::withContext([
+            'request-id' => $requestId
+        ]);
+
+        $response = $next($request);
+
+        $response->headers->set('Request-Id', $requestId);
+
+        return $response;
+    }
+}
+```
+
+If you would like to share contextual information across _all_ logging channels, you may invoke the `Log::shareContext()` method. This method will provide the contextual information to all created channels and any channels that are created subsequently:
+
+```php
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\Response;
+
+class AssignRequestId
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $requestId = (string) Str::uuid();
+
+        Log::shareContext([
+            'request-id' => $requestId
+        ]);
+
+        // ...
+    }
+}
+```
+
+> [!NOTE]
+> If you need to share log context while processing queued jobs, you may utilize [job middleware](/docs/{{version}}/queues#job-middleware).
+
+<a name="writing-to-specific-channels"></a>
+### Writing to Specific Channels
+
+Sometimes you may wish to log a message to a channel other than your application's default channel. You may use the `channel` method on the `Log` facade to retrieve and log to any channel defined in your configuration file:
+
+```php
+use Illuminate\Support\Facades\Log;
+
+Log::channel('slack')->info('Something happened!');
+```
+
+If you would like to create an on-demand logging stack consisting of multiple channels, you may use the `stack` method:
+
+```php
+Log::stack(['single', 'slack'])->info('Something happened!');
+```
+
+<a name="on-demand-channels"></a>
+#### On-Demand Channels
+
+It is also possible to create an on-demand channel by providing the configuration at runtime without that configuration being present in your application's `logging` configuration file. To accomplish this, you may pass a configuration array to the `Log` facade's `build` method:
+
+```php
+use Illuminate\Support\Facades\Log;
+
+Log::build([
+  'driver' => 'single',
+  'path' => storage_path('logs/custom.log'),
+])->info('Something happened!');
+```
+
+You may also wish to include an on-demand channel in an on-demand logging stack. This can be achieved by including your on-demand channel instance in the array passed to the `stack` method:
+
+```php
+use Illuminate\Support\Facades\Log;
+
+$channel = Log::build([
+  'driver' => 'single',
+  'path' => storage_path('logs/custom.log'),
+]);
+
+Log::stack(['slack', $channel])->info('Something happened!');
+```
+
+<a name="monolog-channel-customization"></a>
+## Monolog Channel Customization
+
+<a name="customizing-monolog-for-channels"></a>
+### Customizing Monolog for Channels
+
+Sometimes you may need complete control over how Monolog is configured for an existing channel. For example, you may want to configure a custom Monolog `FormatterInterface` implementation for Laravel's built-in `single` channel.
+
+To get started, define a `tap` array on the channel's configuration. The `tap` array should contain a list of classes that should have an opportunity to customize (or "tap" into) the Monolog instance after it is created. There is no conventional location where these classes should be placed, so you are free to create a directory within your application to contain these classes:
+
+```php
+'single' => [
+    'driver' => 'single',
+    'tap' => [App\Logging\CustomizeFormatter::class],
+    'path' => storage_path('logs/laravel.log'),
+    'level' => env('LOG_LEVEL', 'debug'),
+    'replace_placeholders' => true,
+],
+```
+
+Once you have configured the `tap` option on your channel, you're ready to define the class that will customize your Monolog instance. This class only needs a single method: `__invoke`, which receives an `Illuminate\Log\Logger` instance. The `Illuminate\Log\Logger` instance proxies all method calls to the underlying Monolog instance:
+
+```php
+<?php
+
+namespace App\Logging;
+
+use Illuminate\Log\Logger;
+use Monolog\Formatter\LineFormatter;
+
+class CustomizeFormatter
+{
+    /**
+     * Customize the given logger instance.
+     */
+    public function __invoke(Logger $logger): void
+    {
+        foreach ($logger->getHandlers() as $handler) {
+            $handler->setFormatter(new LineFormatter(
+                '[%datetime%] %channel%.%level_name%: %message% %context% %extra%'
+            ));
+        }
+    }
+}
+```
+
+> [!NOTE]
+> All of your "tap" classes are resolved by the [service container](/docs/{{version}}/container), so any constructor dependencies they require will automatically be injected.
+
+<a name="creating-monolog-handler-channels"></a>
+### Creating Monolog Handler Channels
+
+Monolog has a variety of [available handlers](https://github.com/Seldaek/monolog/tree/main/src/Monolog/Handler) and Laravel does not include a built-in channel for each one. In some cases, you may wish to create a custom channel that is merely an instance of a specific Monolog handler that does not have a corresponding Laravel log driver.  These channels can be easily created using the `monolog` driver.
+
+When using the `monolog` driver, the `handler` configuration option is used to specify which handler will be instantiated. Optionally, any constructor parameters the handler needs may be specified using the `handler_with` configuration option:
+
+```php
+'logentries' => [
+    'driver'  => 'monolog',
+    'handler' => Monolog\Handler\SyslogUdpHandler::class,
+    'handler_with' => [
+        'host' => 'my.logentries.internal.datahubhost.company.com',
+        'port' => '10000',
+    ],
+],
+```
+
+<a name="monolog-formatters"></a>
+#### Monolog Formatters
+
+When using the `monolog` driver, the Monolog `LineFormatter` will be used as the default formatter. However, you may customize the type of formatter passed to the handler using the `formatter` and `formatter_with` configuration options:
+
+```php
+'browser' => [
+    'driver' => 'monolog',
+    'handler' => Monolog\Handler\BrowserConsoleHandler::class,
+    'formatter' => Monolog\Formatter\HtmlFormatter::class,
+    'formatter_with' => [
+        'dateFormat' => 'Y-m-d',
+    ],
+],
+```
+
+If you are using a Monolog handler that is capable of providing its own formatter, you may set the value of the `formatter` configuration option to `default`:
+
+```php
+'newrelic' => [
+    'driver' => 'monolog',
+    'handler' => Monolog\Handler\NewRelicHandler::class,
+    'formatter' => 'default',
+],
+```
+
+<a name="monolog-processors"></a>
+#### Monolog Processors
+
+Monolog can also process messages before logging them. You can create your own processors or use the [existing processors offered by Monolog](https://github.com/Seldaek/monolog/tree/main/src/Monolog/Processor).
+
+If you would like to customize the processors for a `monolog` driver, add a `processors` configuration value to your channel's configuration:
+
+```php
+'memory' => [
+    'driver' => 'monolog',
+    'handler' => Monolog\Handler\StreamHandler::class,
+    'handler_with' => [
+        'stream' => 'php://stderr',
+    ],
+    'processors' => [
+        // Simple syntax...
+        Monolog\Processor\MemoryUsageProcessor::class,
+
+        // With options...
+        [
+            'processor' => Monolog\Processor\PsrLogMessageProcessor::class,
+            'with' => ['removeUsedContextFields' => true],
+        ],
+    ],
+],
+```
+
+<a name="creating-custom-channels-via-factories"></a>
+### Creating Custom Channels via Factories
+
+If you would like to define an entirely custom channel in which you have full control over Monolog's instantiation and configuration, you may specify a `custom` driver type in your `config/logging.php` configuration file. Your configuration should include a `via` option that contains the name of the factory class which will be invoked to create the Monolog instance:
+
+```php
+'channels' => [
+    'example-custom-channel' => [
+        'driver' => 'custom',
+        'via' => App\Logging\CreateCustomLogger::class,
+    ],
+],
+```
+
+Once you have configured the `custom` driver channel, you're ready to define the class that will create your Monolog instance. This class only needs a single `__invoke` method which should return the Monolog logger instance. The method will receive the channels configuration array as its only argument:
+
+```php
+<?php
+
+namespace App\Logging;
+
+use Monolog\Logger;
+
+class CreateCustomLogger
+{
+    /**
+     * Create a custom Monolog instance.
+     */
+    public function __invoke(array $config): Logger
+    {
+        return new Logger(/* ... */);
+    }
+}
+```
+
+<a name="tailing-log-messages-using-pail"></a>
+## Tailing Log Messages Using Pail
+
+Often you may need to tail your application's logs in real time. For example, when debugging an issue or when monitoring your application's logs for specific types of errors.
+
+Laravel Pail is a package that allows you to easily dive into your Laravel application's log files directly from the command line. Unlike the standard `tail` command, Pail is designed to work with any log driver, including Sentry or Flare. In addition, Pail provides a set of useful filters to help you quickly find what you're looking for.
+
+<img src="https://laravel.com/img/docs/pail-example.png">
+
+<a name="pail-installation"></a>
+### Installation
+
+> [!WARNING]
+> Laravel Pail requires [PHP 8.2+](https://php.net/releases/) and the [PCNTL](https://www.php.net/manual/en/book.pcntl.php) extension.
+
+To get started, install Pail into your project using the Composer package manager:
+
+```shell
+composer require laravel/pail
+```
+
+<a name="pail-usage"></a>
+### Usage
+
+To start tailing logs, run the `pail` command:
+
+```shell
+php artisan pail
+```
+
+To increase the verbosity of the output and avoid truncation (…), use the `-v` option:
+
+```shell
+php artisan pail -v
+```
+
+For maximum verbosity and to display exception stack traces, use the `-vv` option:
+
+```shell
+php artisan pail -vv
+```
+
+To stop tailing logs, press `Ctrl+C` at any time.
+
+<a name="pail-filtering-logs"></a>
+### Filtering Logs
+
+<a name="pail-filtering-logs-filter-option"></a>
+#### `--filter`
+
+You may use the `--filter` option to filter logs by their type, file, message, and stack trace content:
+
+```shell
+php artisan pail --filter="QueryException"
+```
+
+<a name="pail-filtering-logs-message-option"></a>
+#### `--message`
+
+To filter logs by only their message, you may use the `--message` option:
+
+```shell
+php artisan pail --message="User created"
+```
+
+<a name="pail-filtering-logs-level-option"></a>
+#### `--level`
+
+The `--level` option may be used to filter logs by their [log level](#log-levels):
+
+```shell
+php artisan pail --level=error
+```
+
+<a name="pail-filtering-logs-user-option"></a>
+#### `--user`
+
+To only display logs that were written while a given user was authenticated, you may provide the user's ID to the `--user` option:
+
+```shell
+php artisan pail --user=1
+```

--- a/sample/translate-deepl.py
+++ b/sample/translate-deepl.py
@@ -3,12 +3,23 @@ import os
 import deepl
 import dotenv
 
+import argparse
+
 def main():
+    # 명령줄 인자 파싱
+    parser = argparse.ArgumentParser(description="Translate a file using DeepL API.")
+    parser.add_argument(
+        "-i", "--input-file",
+        default="logging.md",
+        help="Path to the input file (default: logging.md)"
+    )
+    args = parser.parse_args()
+
     # .env 파일 로드
     dotenv.load_dotenv()
 
     # 파일 경로 설정
-    input_file = "logging.md"
+    input_file = args.input_file
     output_file = f"{os.path.splitext(input_file)[0]}-deepl.md"
 
     # DeepL API 키 가져오기

--- a/sample/translate-deepl.py
+++ b/sample/translate-deepl.py
@@ -1,187 +1,41 @@
 #!/usr/bin/env python3
 import os
-import re
-import subprocess
-import sys
-
-# python-dotenv 라이브러리 설치 확인 및 자동 설치
-try:
-    import dotenv
-except ImportError:
-    print("python-dotenv 라이브러리가 설치되어 있지 않습니다. 설치를 시도합니다...")
-    try:
-        subprocess.check_call([sys.executable, "-m", "pip", "install", "python-dotenv"])
-        import dotenv
-
-        print("python-dotenv 설치 완료!")
-    except Exception as e:
-        print(f"python-dotenv 설치 실패: {e}")
-        print("수동으로 설치해주세요: pip install python-dotenv")
-        sys.exit(1)
-
-# deepl 라이브러리 설치 확인 및 자동 설치
-try:
-    import deepl
-except ImportError:
-    print("deepl 라이브러리가 설치되어 있지 않습니다. 설치를 시도합니다...")
-    try:
-        subprocess.check_call([sys.executable, "-m", "pip", "install", "deepl"])
-        import deepl
-
-        print("deepl 설치 완료!")
-    except Exception as e:
-        print(f"deepl 설치 실패: {e}")
-        print("수동으로 설치해주세요: pip install deepl")
-        sys.exit(1)
-
-
-# 마크다운 파일을 줄 단위로 처리하여 번역해야 할 부분과 보존해야 할 부분을 구분하는 함수
-def extract_translatable_content(markdown_text):
-    # 줄 단위로 분리
-    lines = markdown_text.split('\n')
-    translatable_lines = []
-    non_translatable_lines = []
-    in_code_block = False
-
-    # 각 줄을 처리
-    for i, line in enumerate(lines):
-        # 코드 블록 시작/종료 확인
-        if line.strip().startswith('```'):
-            in_code_block = not in_code_block
-            non_translatable_lines.append((i, line))
-            continue
-
-        # 코드 블록 내부인 경우 번역하지 않음
-        if in_code_block:
-            non_translatable_lines.append((i, line))
-            continue
-
-        # HTML 태그나 링크만 있는 줄 처리
-        if re.match(r'^<[^>]+>$', line.strip()) or \
-                re.match(r'^\[.*\]\(.*\)$', line.strip()) or \
-                re.match(r'^\s*$', line.strip()) or \
-                line.strip().startswith('> [!') or \
-                line.strip().startswith('- [') or \
-                line.strip().startswith('# ') or \
-                line.strip().startswith('## ') or \
-                line.strip().startswith('### ') or \
-                line.strip().startswith('#### ') or \
-                line.strip().startswith('##### ') or \
-                line.strip().startswith('###### '):
-            non_translatable_lines.append((i, line))
-            continue
-
-        # 번역해야 할 줄
-        translatable_lines.append((i, line))
-
-    # 번역할 줄만 모아서 하나의 텍스트로 합치기
-    translatable_text = '\n'.join([line for _, line in translatable_lines])
-
-    print(f"\n번역할 줄: {len(translatable_lines)}")
-    print(f"번역하지 않을 줄: {len(non_translatable_lines)}")
-
-    return translatable_text, translatable_lines, non_translatable_lines
-
-
-# 번역된 텍스트와 번역되지 않은 원본 줄을 합쳐서 최종 결과를 생성하는 함수
-def merge_translations(translated_text, translatable_lines, non_translatable_lines, original_lines):
-    # 번역된 텍스트를 줄 단위로 분리
-    translated_lines = translated_text.split('\n')
-
-    # 번역할 줄 개수와 번역된 줄 개수가 다르면 오류 처리
-    if len(translated_lines) != len(translatable_lines):
-        print(f"\n경고: 번역된 줄 개수({len(translated_lines)})가 번역할 줄 개수({len(translatable_lines)})와 다릅니다.")
-        # 더 적은 개수를 기준으로 처리
-        min_lines = min(len(translated_lines), len(translatable_lines))
-        translatable_lines = translatable_lines[:min_lines]
-        translated_lines = translated_lines[:min_lines]
-
-    # 번역된 줄과 번역되지 않은 원본 줄을 합쳐서 최종 결과 생성
-    result_lines = original_lines.copy()  # 원본 전체 줄 복사
-
-    # 번역된 줄 삽입
-    for i, (original_line_num, _) in enumerate(translatable_lines):
-        result_lines[original_line_num] = translated_lines[i]
-
-    # 최종 결과 합치기
-    return '\n'.join(result_lines)
-
+import deepl
+import dotenv
 
 def main():
     # .env 파일 로드
     dotenv.load_dotenv()
 
-    # 번역할 파일 경로 설정 (여기에서 직접 수정하세요)
-    input_file = "logging.md"  # 번역할 파일 경로
-    output_file = "logging-deepl.md"  # 번역 결과를 저장할 파일 경로
-    source_lang = "EN"  # 원본 언어 코드 (EN: 영어, DE: 독일어 등)
-    target_lang = "ko"  # 대상 언어 코드 (ko: 한국어, ja: 일본어, zh: 중국어 등)
+    # 파일 경로 설정
+    input_file = "logging.md"
+    output_file = f"{os.path.splitext(input_file)[0]}-deepl.md"
 
-    # API 키 확인 (.env 파일에서 가져오기)
+    # DeepL API 키 가져오기
     api_key = os.environ.get("DEEPL_API_KEY")
     if not api_key:
-        print("오류: DEEPL_API_KEY가 설정되지 않았습니다.")
-        print(".env 파일을 생성하고 다음 내용을 추가하세요:")
-        print("DEEPL_API_KEY=your_api_key_here")
-
-        # .env 파일 자동 생성 예시
-        if not os.path.exists("../.env"):
-            try:
-                with open("../.env", "w") as f:
-                    f.write("DEEPL_API_KEY=\n")
-                print(".env 파일이 생성되었습니다. API 키를 추가하고 다시 실행하세요.")
-            except Exception as e:
-                print(f".env 파일 생성 실패: {e}")
+        print("DEEPL_API_KEY가 설정되지 않았습니다.")
         return
 
-    # 입력 파일 확인
-    if not os.path.exists(input_file):
-        print(f"오류: 입력 파일 '{input_file}'이 존재하지 않습니다.")
-        return
+    # 파일 읽기
+    with open(input_file, 'r', encoding='utf-8') as f:
+        content = f.read()
 
-    try:
-        # 원본 파일 읽기
-        with open(input_file, 'r', encoding='utf-8') as f:
-            content = f.read()
-            print(f"파일 '{input_file}'을 읽었습니다. (크기: {len(content)} 바이트)")
+    # DeepL 번역
+    translator = deepl.Translator(api_key)
+    result = translator.translate_text(
+        content,
+        source_lang="EN",
+        target_lang="KO",
+        tag_handling="html",
+        ignore_tags=["code", "pre", "a"]
+    )
 
-        # 원본 파일을 줄 단위로 분리
-        original_lines = content.split('\n')
+    # 결과 저장
+    with open(output_file, 'w', encoding='utf-8') as f:
+        f.write(result.text)
 
-        # 번역해야 할 부분과 보존해야 할 부분 구분
-        translatable_text, translatable_lines, non_translatable_lines = extract_translatable_content(content)
-
-        # 번역할 텍스트가 없으면 원본 그대로 저장
-        if not translatable_text.strip():
-            print("번역할 텍스트가 없습니다. 원본 파일을 그대로 복사합니다.")
-            shutil.copy2(input_file, output_file)
-            return
-
-        # DeepL API로 번역
-        print(f"DeepL API를 사용하여 '{source_lang}'에서 '{target_lang}'로 번역 중...")
-        deepl_client = deepl.DeepLClient(api_key)
-        result = deepl_client.translate_text(
-            translatable_text,
-            target_lang=target_lang.upper(),
-            source_lang=source_lang.upper(),
-            preserve_formatting=True
-        )
-        translated_text = result.text
-
-        # 번역된 텍스트와 번역되지 않은 원본 줄을 합쳐서 최종 결과 생성
-        final_content = merge_translations(translated_text, translatable_lines, non_translatable_lines, original_lines)
-
-        # 번역된 내용 저장
-        with open(output_file, 'w', encoding='utf-8') as f:
-            f.write(final_content)
-
-        print(f"번역 완료! 결과가 '{output_file}'에 저장되었습니다.")
-        print(f"번역된 텍스트 크기: {len(final_content)} 바이트")
-        print(f"청구된 문자 수: {result.billed_characters}")
-
-    except Exception as e:
-        print(f"오류 발생: {e}")
-
+    print(f"번역 완료: {output_file}")
 
 if __name__ == "__main__":
     main()

--- a/sample/translate-deepl.py
+++ b/sample/translate-deepl.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+import os
+import re
+import subprocess
+import sys
+
+# python-dotenv 라이브러리 설치 확인 및 자동 설치
+try:
+    import dotenv
+except ImportError:
+    print("python-dotenv 라이브러리가 설치되어 있지 않습니다. 설치를 시도합니다...")
+    try:
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "python-dotenv"])
+        import dotenv
+
+        print("python-dotenv 설치 완료!")
+    except Exception as e:
+        print(f"python-dotenv 설치 실패: {e}")
+        print("수동으로 설치해주세요: pip install python-dotenv")
+        sys.exit(1)
+
+# deepl 라이브러리 설치 확인 및 자동 설치
+try:
+    import deepl
+except ImportError:
+    print("deepl 라이브러리가 설치되어 있지 않습니다. 설치를 시도합니다...")
+    try:
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "deepl"])
+        import deepl
+
+        print("deepl 설치 완료!")
+    except Exception as e:
+        print(f"deepl 설치 실패: {e}")
+        print("수동으로 설치해주세요: pip install deepl")
+        sys.exit(1)
+
+
+# 마크다운 파일을 줄 단위로 처리하여 번역해야 할 부분과 보존해야 할 부분을 구분하는 함수
+def extract_translatable_content(markdown_text):
+    # 줄 단위로 분리
+    lines = markdown_text.split('\n')
+    translatable_lines = []
+    non_translatable_lines = []
+    in_code_block = False
+
+    # 각 줄을 처리
+    for i, line in enumerate(lines):
+        # 코드 블록 시작/종료 확인
+        if line.strip().startswith('```'):
+            in_code_block = not in_code_block
+            non_translatable_lines.append((i, line))
+            continue
+
+        # 코드 블록 내부인 경우 번역하지 않음
+        if in_code_block:
+            non_translatable_lines.append((i, line))
+            continue
+
+        # HTML 태그나 링크만 있는 줄 처리
+        if re.match(r'^<[^>]+>$', line.strip()) or \
+                re.match(r'^\[.*\]\(.*\)$', line.strip()) or \
+                re.match(r'^\s*$', line.strip()) or \
+                line.strip().startswith('> [!') or \
+                line.strip().startswith('- [') or \
+                line.strip().startswith('# ') or \
+                line.strip().startswith('## ') or \
+                line.strip().startswith('### ') or \
+                line.strip().startswith('#### ') or \
+                line.strip().startswith('##### ') or \
+                line.strip().startswith('###### '):
+            non_translatable_lines.append((i, line))
+            continue
+
+        # 번역해야 할 줄
+        translatable_lines.append((i, line))
+
+    # 번역할 줄만 모아서 하나의 텍스트로 합치기
+    translatable_text = '\n'.join([line for _, line in translatable_lines])
+
+    print(f"\n번역할 줄: {len(translatable_lines)}")
+    print(f"번역하지 않을 줄: {len(non_translatable_lines)}")
+
+    return translatable_text, translatable_lines, non_translatable_lines
+
+
+# 번역된 텍스트와 번역되지 않은 원본 줄을 합쳐서 최종 결과를 생성하는 함수
+def merge_translations(translated_text, translatable_lines, non_translatable_lines, original_lines):
+    # 번역된 텍스트를 줄 단위로 분리
+    translated_lines = translated_text.split('\n')
+
+    # 번역할 줄 개수와 번역된 줄 개수가 다르면 오류 처리
+    if len(translated_lines) != len(translatable_lines):
+        print(f"\n경고: 번역된 줄 개수({len(translated_lines)})가 번역할 줄 개수({len(translatable_lines)})와 다릅니다.")
+        # 더 적은 개수를 기준으로 처리
+        min_lines = min(len(translated_lines), len(translatable_lines))
+        translatable_lines = translatable_lines[:min_lines]
+        translated_lines = translated_lines[:min_lines]
+
+    # 번역된 줄과 번역되지 않은 원본 줄을 합쳐서 최종 결과 생성
+    result_lines = original_lines.copy()  # 원본 전체 줄 복사
+
+    # 번역된 줄 삽입
+    for i, (original_line_num, _) in enumerate(translatable_lines):
+        result_lines[original_line_num] = translated_lines[i]
+
+    # 최종 결과 합치기
+    return '\n'.join(result_lines)
+
+
+def main():
+    # .env 파일 로드
+    dotenv.load_dotenv()
+
+    # 번역할 파일 경로 설정 (여기에서 직접 수정하세요)
+    input_file = "logging.md"  # 번역할 파일 경로
+    output_file = "logging-deepl.md"  # 번역 결과를 저장할 파일 경로
+    source_lang = "EN"  # 원본 언어 코드 (EN: 영어, DE: 독일어 등)
+    target_lang = "ko"  # 대상 언어 코드 (ko: 한국어, ja: 일본어, zh: 중국어 등)
+
+    # API 키 확인 (.env 파일에서 가져오기)
+    api_key = os.environ.get("DEEPL_API_KEY")
+    if not api_key:
+        print("오류: DEEPL_API_KEY가 설정되지 않았습니다.")
+        print(".env 파일을 생성하고 다음 내용을 추가하세요:")
+        print("DEEPL_API_KEY=your_api_key_here")
+
+        # .env 파일 자동 생성 예시
+        if not os.path.exists("../.env"):
+            try:
+                with open("../.env", "w") as f:
+                    f.write("DEEPL_API_KEY=\n")
+                print(".env 파일이 생성되었습니다. API 키를 추가하고 다시 실행하세요.")
+            except Exception as e:
+                print(f".env 파일 생성 실패: {e}")
+        return
+
+    # 입력 파일 확인
+    if not os.path.exists(input_file):
+        print(f"오류: 입력 파일 '{input_file}'이 존재하지 않습니다.")
+        return
+
+    try:
+        # 원본 파일 읽기
+        with open(input_file, 'r', encoding='utf-8') as f:
+            content = f.read()
+            print(f"파일 '{input_file}'을 읽었습니다. (크기: {len(content)} 바이트)")
+
+        # 원본 파일을 줄 단위로 분리
+        original_lines = content.split('\n')
+
+        # 번역해야 할 부분과 보존해야 할 부분 구분
+        translatable_text, translatable_lines, non_translatable_lines = extract_translatable_content(content)
+
+        # 번역할 텍스트가 없으면 원본 그대로 저장
+        if not translatable_text.strip():
+            print("번역할 텍스트가 없습니다. 원본 파일을 그대로 복사합니다.")
+            shutil.copy2(input_file, output_file)
+            return
+
+        # DeepL API로 번역
+        print(f"DeepL API를 사용하여 '{source_lang}'에서 '{target_lang}'로 번역 중...")
+        deepl_client = deepl.DeepLClient(api_key)
+        result = deepl_client.translate_text(
+            translatable_text,
+            target_lang=target_lang.upper(),
+            source_lang=source_lang.upper(),
+            preserve_formatting=True
+        )
+        translated_text = result.text
+
+        # 번역된 텍스트와 번역되지 않은 원본 줄을 합쳐서 최종 결과 생성
+        final_content = merge_translations(translated_text, translatable_lines, non_translatable_lines, original_lines)
+
+        # 번역된 내용 저장
+        with open(output_file, 'w', encoding='utf-8') as f:
+            f.write(final_content)
+
+        print(f"번역 완료! 결과가 '{output_file}'에 저장되었습니다.")
+        print(f"번역된 텍스트 크기: {len(final_content)} 바이트")
+        print(f"청구된 문자 수: {result.billed_characters}")
+
+    except Exception as e:
+        print(f"오류 발생: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sample/translate-openai.py
+++ b/sample/translate-openai.py
@@ -23,7 +23,6 @@ def main():
 
     # OpenAI 번역
     openai.api_key = api_key
-    client = openai.OpenAI()
 
     # 시스템 프롬프트 설정
     system_prompt = f"""당신은 전문 번역가입니다. EN에서 ko로 마크다운 문서를 번역해주세요.

--- a/sample/translate-openai.py
+++ b/sample/translate-openai.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 import os
-import re
-import subprocess
 import sys
+import subprocess
 
 # python-dotenv 라이브러리 설치 확인 및 자동 설치
 try:
@@ -12,7 +11,6 @@ except ImportError:
     try:
         subprocess.check_call([sys.executable, "-m", "pip", "install", "python-dotenv"])
         import dotenv
-
         print("python-dotenv 설치 완료!")
     except Exception as e:
         print(f"python-dotenv 설치 실패: {e}")
@@ -27,128 +25,11 @@ except ImportError:
     try:
         subprocess.check_call([sys.executable, "-m", "pip", "install", "openai"])
         import openai
-
         print("openai 설치 완료!")
     except Exception as e:
         print(f"openai 설치 실패: {e}")
         print("수동으로 설치해주세요: pip install openai")
         sys.exit(1)
-
-
-# 마크다운 파일을 줄 단위로 처리하여 번역해야 할 부분과 보존해야 할 부분을 구분하는 함수
-def extract_translatable_content(markdown_text):
-    # 줄 단위로 분리
-    lines = markdown_text.split('\n')
-    translatable_lines = []
-    non_translatable_lines = []
-    in_code_block = False
-
-    # 각 줄을 처리
-    for i, line in enumerate(lines):
-        # 코드 블록 시작/종료 확인
-        if line.strip().startswith('```'):
-            in_code_block = not in_code_block
-            non_translatable_lines.append((i, line))
-            continue
-
-        # 코드 블록 내부인 경우 번역하지 않음
-        if in_code_block:
-            non_translatable_lines.append((i, line))
-            continue
-
-        # HTML 태그나 링크만 있는 줄 처리
-        if re.match(r'^<[^>]+>$', line.strip()) or \
-                re.match(r'^\[.*\]\(.*\)$', line.strip()) or \
-                re.match(r'^\s*$', line.strip()) or \
-                line.strip().startswith('> [!') or \
-                line.strip().startswith('- [') or \
-                line.strip().startswith('# ') or \
-                line.strip().startswith('## ') or \
-                line.strip().startswith('### ') or \
-                line.strip().startswith('#### ') or \
-                line.strip().startswith('##### ') or \
-                line.strip().startswith('###### '):
-            non_translatable_lines.append((i, line))
-            continue
-
-        # 번역해야 할 줄
-        translatable_lines.append((i, line))
-
-    # 번역할 줄만 모아서 하나의 텍스트로 합치기
-    translatable_text = '\n'.join([line for _, line in translatable_lines])
-
-    print(f"\n번역할 줄: {len(translatable_lines)}")
-    print(f"번역하지 않을 줄: {len(non_translatable_lines)}")
-
-    return translatable_text, translatable_lines, non_translatable_lines
-
-
-# 번역된 텍스트와 번역되지 않은 원본 줄을 합쳐서 최종 결과를 생성하는 함수
-def merge_translations(translated_text, translatable_lines, non_translatable_lines, original_lines):
-    # 번역된 텍스트를 줄 단위로 분리
-    translated_lines = translated_text.split('\n')
-
-    # 번역할 줄 개수와 번역된 줄 개수가 다르면 오류 처리
-    if len(translated_lines) != len(translatable_lines):
-        print(f"\n경고: 번역된 줄 개수({len(translated_lines)})가 번역할 줄 개수({len(translatable_lines)})와 다릅니다.")
-        # 더 적은 개수를 기준으로 처리
-        min_lines = min(len(translated_lines), len(translatable_lines))
-        translatable_lines = translatable_lines[:min_lines]
-        translated_lines = translated_lines[:min_lines]
-
-    # 번역된 줄과 번역되지 않은 원본 줄을 합쳐서 최종 결과 생성
-    result_lines = original_lines.copy()  # 원본 전체 줄 복사
-
-    # 번역된 줄 삽입
-    for i, (original_line_num, _) in enumerate(translatable_lines):
-        result_lines[original_line_num] = translated_lines[i]
-
-    # 최종 결과 합치기
-    return '\n'.join(result_lines)
-
-
-# OpenAI API를 사용하여 텍스트 번역
-def translate_with_openai(text, target_lang="ko", source_lang="EN", model="o1"):
-    client = openai.OpenAI()
-
-    # 번역 요청 생성 - 상세한 지침 추가
-    system_prompt = f"""당신은 전문 번역가입니다. {source_lang}에서 {target_lang}로 텍스트를 번역해주세요.
-
-중요한 지침:
-1. 원본 텍스트의 줄바꿈과 형식을 정확히 유지하세요. 추가 줄바꿈을 삽입하지 마세요.
-2. 코드 블록, HTML 태그, 링크, 마크다운 구문은 절대 번역하지 마세요.
-3. 텍스트만 번역하고, 텍스트 이외의 요소는 그대로 유지하세요.
-4. 원본 텍스트의 줄 수와 번역된 텍스트의 줄 수가 정확히 일치해야 합니다.
-"""
-
-    try:
-        # o1 모델은 temperature 매개변수를 지원하지 않음
-        params = {
-            "model": model,
-            "messages": [
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": f"다음 텍스트를 {target_lang}로 번역해주세요. 원본 형식을 정확히 유지해주세요:\n\n{text}"}
-            ]
-        }
-
-        # o1 모델이 아닌 경우에만 temperature 설정
-        if not model.startswith('o1'):
-            params["temperature"] = 0.3  # 낮은 온도로 일관된 번역 결과 유도
-
-        response = client.chat.completions.create(**params)
-
-        # 번역 결과 반환
-        translated_text = response.choices[0].message.content
-
-        # 토큰 사용량 출력
-        print(f"사용된 토큰: {response.usage.total_tokens}")
-
-        return translated_text
-
-    except Exception as e:
-        print(f"OpenAI API 오류: {e}")
-        return text  # 오류 발생 시 원본 텍스트 반환
-
 
 def main():
     # .env 파일 로드
@@ -156,7 +37,8 @@ def main():
 
     # 번역할 파일 경로 설정 (여기에서 직접 수정하세요)
     input_file = "logging.md"  # 번역할 파일 경로
-    output_file = "logging-openai.md"  # 번역 결과를 저장할 파일 경로
+    # 출력 파일명을 {원본파일명}-openai.md 형식으로 자동 생성
+    output_file = f"{os.path.splitext(input_file)[0]}-openai.md"  # 번역 결과를 저장할 파일 경로
     source_lang = "EN"  # 원본 언어 코드 (EN: 영어, DE: 독일어 등)
     target_lang = "ko"  # 대상 언어 코드 (ko: 한국어, ja: 일본어, zh: 중국어 등)
 
@@ -173,6 +55,7 @@ def main():
 
     # OpenAI 클라이언트 설정
     openai.api_key = api_key
+    client = openai.OpenAI()
 
     # 입력 파일 확인
     if not os.path.exists(input_file):
@@ -185,90 +68,45 @@ def main():
             content = f.read()
             print(f"파일 '{input_file}'을 읽었습니다. (크기: {len(content)} 바이트)")
 
-        # 원본 파일을 줄 단위로 분리
-        original_lines = content.split('\n')
+        # 시스템 프롬프트 설정
+        system_prompt = f"""당신은 전문 번역가입니다. {source_lang}에서 {target_lang}로 마크다운 문서를 번역해주세요.
 
-        # 번역해야 할 부분과 보존해야 할 부분 구분
-        translatable_text, translatable_lines, non_translatable_lines = extract_translatable_content(content)
+중요한 지침:
+1. 코드 블록, HTML 태그, 링크 URL은 번역하지 마세요.
+2. 마크다운 형식을 유지하세요.
+3. 전문 용어는 적절하게 번역하세요.
+"""
 
-        # 번역할 텍스트가 없으면 원본 그대로 저장
-        if not translatable_text.strip():
-            print("번역할 텍스트가 없습니다. 원본 파일을 그대로 복사합니다.")
-            with open(output_file, 'w', encoding='utf-8') as f:
-                f.write(content)
-            return
+        # OpenAI API로 번역
+        print(f"OpenAI API를 사용하여 '{source_lang}'에서 '{target_lang}'로 번역 중...")
 
-        # 텍스트가 너무 길면 청크로 나누기
-        max_chunk_size = 4000  # 약 4000자 단위로 나누기
-        chunks = []
+        # API 요청 파라미터 설정
+        params = {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": f"다음 마크다운 문서를 {target_lang}로 번역해주세요:\n\n{content}"}
+            ]
+        }
 
-        if len(translatable_text) > max_chunk_size:
-            # 문단 단위로 청크 나누기 (빈 줄을 기준으로 문단 구분)
-            paragraphs = []
-            current_paragraph = []
+        # API 호출
+        response = client.chat.completions.create(**params)
 
-            for line in translatable_text.split('\n'):
-                if line.strip() == '':
-                    if current_paragraph:
-                        paragraphs.append('\n'.join(current_paragraph))
-                        current_paragraph = []
-                    paragraphs.append('')  # 빈 줄 추가
-                else:
-                    current_paragraph.append(line)
+        # 번역 결과 추출
+        translated_content = response.choices[0].message.content
 
-            if current_paragraph:  # 마지막 문단 추가
-                paragraphs.append('\n'.join(current_paragraph))
-
-            # 문단을 청크로 묶기
-            current_chunk = []
-            current_size = 0
-
-            for paragraph in paragraphs:
-                paragraph_size = len(paragraph) + 1  # \n 문자 포함
-
-                if current_size + paragraph_size > max_chunk_size and current_chunk:
-                    chunks.append('\n'.join(current_chunk))
-                    current_chunk = [paragraph]
-                    current_size = paragraph_size
-                else:
-                    current_chunk.append(paragraph)
-                    current_size += paragraph_size
-
-            if current_chunk:  # 마지막 청크 추가
-                chunks.append('\n'.join(current_chunk))
-
-            print(f"텍스트를 {len(chunks)}개의 청크로 나누었습니다.")
-        else:
-            chunks = [translatable_text]
-
-        # 각 청크 번역
-        translated_chunks = []
-        for i, chunk in enumerate(chunks):
-            print(f"청크 {i + 1}/{len(chunks)} 번역 중... (크기: {len(chunk)} 자)")
-            translated_chunk = translate_with_openai(
-                chunk,
-                target_lang=target_lang,
-                source_lang=source_lang,
-                model=model
-            )
-            translated_chunks.append(translated_chunk)
-
-        # 번역된 청크 합치기
-        translated_text = '\n'.join(translated_chunks)
-
-        # 번역된 텍스트와 번역되지 않은 원본 줄을 합쳐서 최종 결과 생성
-        final_content = merge_translations(translated_text, translatable_lines, non_translatable_lines, original_lines)
+        # 토큰 사용량 출력
+        print(f"사용된 토큰: {response.usage.total_tokens}")
 
         # 번역된 내용 저장
         with open(output_file, 'w', encoding='utf-8') as f:
-            f.write(final_content)
+            f.write(translated_content)
 
         print(f"번역 완료! 결과가 '{output_file}'에 저장되었습니다.")
-        print(f"번역된 텍스트 크기: {len(final_content)} 바이트")
+        print(f"번역된 텍스트 크기: {len(translated_content)} 바이트")
 
     except Exception as e:
         print(f"오류 발생: {e}")
-
 
 if __name__ == "__main__":
     main()

--- a/sample/translate-openai.py
+++ b/sample/translate-openai.py
@@ -4,13 +4,19 @@ import openai
 import dotenv
 
 def main():
+    import argparse
+
+    # 명령줄 인수 파싱
+    parser = argparse.ArgumentParser(description="Translate a Markdown file using OpenAI.")
+    parser.add_argument("input_file", nargs="?", default="logging.md", help="Path to the input Markdown file.")
+    parser.add_argument("output_file", nargs="?", default="logging-openai.md", help="Path to the output Markdown file.")
+    args = parser.parse_args()
+
+    input_file = args.input_file
+    output_file = args.output_file
+
     # .env 파일 로드
     dotenv.load_dotenv()
-
-    # 파일 경로 설정
-    input_file = "logging.md"
-    output_file = "logging-openai.md"
-
     # OpenAI API 키 가져오기
     api_key = os.environ.get("OPENAI_API_KEY")
     if not api_key:

--- a/sample/translate-openai.py
+++ b/sample/translate-openai.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+import os
+import re
+import subprocess
+import sys
+
+# python-dotenv 라이브러리 설치 확인 및 자동 설치
+try:
+    import dotenv
+except ImportError:
+    print("python-dotenv 라이브러리가 설치되어 있지 않습니다. 설치를 시도합니다...")
+    try:
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "python-dotenv"])
+        import dotenv
+
+        print("python-dotenv 설치 완료!")
+    except Exception as e:
+        print(f"python-dotenv 설치 실패: {e}")
+        print("수동으로 설치해주세요: pip install python-dotenv")
+        sys.exit(1)
+
+# openai 라이브러리 설치 확인 및 자동 설치
+try:
+    import openai
+except ImportError:
+    print("openai 라이브러리가 설치되어 있지 않습니다. 설치를 시도합니다...")
+    try:
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "openai"])
+        import openai
+
+        print("openai 설치 완료!")
+    except Exception as e:
+        print(f"openai 설치 실패: {e}")
+        print("수동으로 설치해주세요: pip install openai")
+        sys.exit(1)
+
+
+# 마크다운 파일을 줄 단위로 처리하여 번역해야 할 부분과 보존해야 할 부분을 구분하는 함수
+def extract_translatable_content(markdown_text):
+    # 줄 단위로 분리
+    lines = markdown_text.split('\n')
+    translatable_lines = []
+    non_translatable_lines = []
+    in_code_block = False
+
+    # 각 줄을 처리
+    for i, line in enumerate(lines):
+        # 코드 블록 시작/종료 확인
+        if line.strip().startswith('```'):
+            in_code_block = not in_code_block
+            non_translatable_lines.append((i, line))
+            continue
+
+        # 코드 블록 내부인 경우 번역하지 않음
+        if in_code_block:
+            non_translatable_lines.append((i, line))
+            continue
+
+        # HTML 태그나 링크만 있는 줄 처리
+        if re.match(r'^<[^>]+>$', line.strip()) or \
+                re.match(r'^\[.*\]\(.*\)$', line.strip()) or \
+                re.match(r'^\s*$', line.strip()) or \
+                line.strip().startswith('> [!') or \
+                line.strip().startswith('- [') or \
+                line.strip().startswith('# ') or \
+                line.strip().startswith('## ') or \
+                line.strip().startswith('### ') or \
+                line.strip().startswith('#### ') or \
+                line.strip().startswith('##### ') or \
+                line.strip().startswith('###### '):
+            non_translatable_lines.append((i, line))
+            continue
+
+        # 번역해야 할 줄
+        translatable_lines.append((i, line))
+
+    # 번역할 줄만 모아서 하나의 텍스트로 합치기
+    translatable_text = '\n'.join([line for _, line in translatable_lines])
+
+    print(f"\n번역할 줄: {len(translatable_lines)}")
+    print(f"번역하지 않을 줄: {len(non_translatable_lines)}")
+
+    return translatable_text, translatable_lines, non_translatable_lines
+
+
+# 번역된 텍스트와 번역되지 않은 원본 줄을 합쳐서 최종 결과를 생성하는 함수
+def merge_translations(translated_text, translatable_lines, non_translatable_lines, original_lines):
+    # 번역된 텍스트를 줄 단위로 분리
+    translated_lines = translated_text.split('\n')
+
+    # 번역할 줄 개수와 번역된 줄 개수가 다르면 오류 처리
+    if len(translated_lines) != len(translatable_lines):
+        print(f"\n경고: 번역된 줄 개수({len(translated_lines)})가 번역할 줄 개수({len(translatable_lines)})와 다릅니다.")
+        # 더 적은 개수를 기준으로 처리
+        min_lines = min(len(translated_lines), len(translatable_lines))
+        translatable_lines = translatable_lines[:min_lines]
+        translated_lines = translated_lines[:min_lines]
+
+    # 번역된 줄과 번역되지 않은 원본 줄을 합쳐서 최종 결과 생성
+    result_lines = original_lines.copy()  # 원본 전체 줄 복사
+
+    # 번역된 줄 삽입
+    for i, (original_line_num, _) in enumerate(translatable_lines):
+        result_lines[original_line_num] = translated_lines[i]
+
+    # 최종 결과 합치기
+    return '\n'.join(result_lines)
+
+
+# OpenAI API를 사용하여 텍스트 번역
+def translate_with_openai(text, target_lang="ko", source_lang="EN", model="o1"):
+    client = openai.OpenAI()
+
+    # 번역 요청 생성 - 상세한 지침 추가
+    system_prompt = f"""당신은 전문 번역가입니다. {source_lang}에서 {target_lang}로 텍스트를 번역해주세요.
+
+중요한 지침:
+1. 원본 텍스트의 줄바꿈과 형식을 정확히 유지하세요. 추가 줄바꿈을 삽입하지 마세요.
+2. 코드 블록, HTML 태그, 링크, 마크다운 구문은 절대 번역하지 마세요.
+3. 텍스트만 번역하고, 텍스트 이외의 요소는 그대로 유지하세요.
+4. 원본 텍스트의 줄 수와 번역된 텍스트의 줄 수가 정확히 일치해야 합니다.
+"""
+
+    try:
+        # o1 모델은 temperature 매개변수를 지원하지 않음
+        params = {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": f"다음 텍스트를 {target_lang}로 번역해주세요. 원본 형식을 정확히 유지해주세요:\n\n{text}"}
+            ]
+        }
+
+        # o1 모델이 아닌 경우에만 temperature 설정
+        if not model.startswith('o1'):
+            params["temperature"] = 0.3  # 낮은 온도로 일관된 번역 결과 유도
+
+        response = client.chat.completions.create(**params)
+
+        # 번역 결과 반환
+        translated_text = response.choices[0].message.content
+
+        # 토큰 사용량 출력
+        print(f"사용된 토큰: {response.usage.total_tokens}")
+
+        return translated_text
+
+    except Exception as e:
+        print(f"OpenAI API 오류: {e}")
+        return text  # 오류 발생 시 원본 텍스트 반환
+
+
+def main():
+    # .env 파일 로드
+    dotenv.load_dotenv()
+
+    # 번역할 파일 경로 설정 (여기에서 직접 수정하세요)
+    input_file = "logging.md"  # 번역할 파일 경로
+    output_file = "logging-openai.md"  # 번역 결과를 저장할 파일 경로
+    source_lang = "EN"  # 원본 언어 코드 (EN: 영어, DE: 독일어 등)
+    target_lang = "ko"  # 대상 언어 코드 (ko: 한국어, ja: 일본어, zh: 중국어 등)
+
+    # 모델 설정
+    model = os.environ.get("TRANSLATION_MODEL", "o1")
+
+    # API 키 확인 (.env 파일에서 가져오기)
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        print("오류: OPENAI_API_KEY가 설정되지 않았습니다.")
+        print(".env 파일을 생성하고 다음 내용을 추가하세요:")
+        print("OPENAI_API_KEY=your_api_key_here")
+        return
+
+    # OpenAI 클라이언트 설정
+    openai.api_key = api_key
+
+    # 입력 파일 확인
+    if not os.path.exists(input_file):
+        print(f"오류: 입력 파일 '{input_file}'이 존재하지 않습니다.")
+        return
+
+    try:
+        # 원본 파일 읽기
+        with open(input_file, 'r', encoding='utf-8') as f:
+            content = f.read()
+            print(f"파일 '{input_file}'을 읽었습니다. (크기: {len(content)} 바이트)")
+
+        # 원본 파일을 줄 단위로 분리
+        original_lines = content.split('\n')
+
+        # 번역해야 할 부분과 보존해야 할 부분 구분
+        translatable_text, translatable_lines, non_translatable_lines = extract_translatable_content(content)
+
+        # 번역할 텍스트가 없으면 원본 그대로 저장
+        if not translatable_text.strip():
+            print("번역할 텍스트가 없습니다. 원본 파일을 그대로 복사합니다.")
+            with open(output_file, 'w', encoding='utf-8') as f:
+                f.write(content)
+            return
+
+        # 텍스트가 너무 길면 청크로 나누기
+        max_chunk_size = 4000  # 약 4000자 단위로 나누기
+        chunks = []
+
+        if len(translatable_text) > max_chunk_size:
+            # 문단 단위로 청크 나누기 (빈 줄을 기준으로 문단 구분)
+            paragraphs = []
+            current_paragraph = []
+
+            for line in translatable_text.split('\n'):
+                if line.strip() == '':
+                    if current_paragraph:
+                        paragraphs.append('\n'.join(current_paragraph))
+                        current_paragraph = []
+                    paragraphs.append('')  # 빈 줄 추가
+                else:
+                    current_paragraph.append(line)
+
+            if current_paragraph:  # 마지막 문단 추가
+                paragraphs.append('\n'.join(current_paragraph))
+
+            # 문단을 청크로 묶기
+            current_chunk = []
+            current_size = 0
+
+            for paragraph in paragraphs:
+                paragraph_size = len(paragraph) + 1  # \n 문자 포함
+
+                if current_size + paragraph_size > max_chunk_size and current_chunk:
+                    chunks.append('\n'.join(current_chunk))
+                    current_chunk = [paragraph]
+                    current_size = paragraph_size
+                else:
+                    current_chunk.append(paragraph)
+                    current_size += paragraph_size
+
+            if current_chunk:  # 마지막 청크 추가
+                chunks.append('\n'.join(current_chunk))
+
+            print(f"텍스트를 {len(chunks)}개의 청크로 나누었습니다.")
+        else:
+            chunks = [translatable_text]
+
+        # 각 청크 번역
+        translated_chunks = []
+        for i, chunk in enumerate(chunks):
+            print(f"청크 {i + 1}/{len(chunks)} 번역 중... (크기: {len(chunk)} 자)")
+            translated_chunk = translate_with_openai(
+                chunk,
+                target_lang=target_lang,
+                source_lang=source_lang,
+                model=model
+            )
+            translated_chunks.append(translated_chunk)
+
+        # 번역된 청크 합치기
+        translated_text = '\n'.join(translated_chunks)
+
+        # 번역된 텍스트와 번역되지 않은 원본 줄을 합쳐서 최종 결과 생성
+        final_content = merge_translations(translated_text, translatable_lines, non_translatable_lines, original_lines)
+
+        # 번역된 내용 저장
+        with open(output_file, 'w', encoding='utf-8') as f:
+            f.write(final_content)
+
+        print(f"번역 완료! 결과가 '{output_file}'에 저장되었습니다.")
+        print(f"번역된 텍스트 크기: {len(final_content)} 바이트")
+
+    except Exception as e:
+        print(f"오류 발생: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sample/translate-openai.py
+++ b/sample/translate-openai.py
@@ -1,75 +1,32 @@
 #!/usr/bin/env python3
 import os
-import sys
-import subprocess
-
-# python-dotenv 라이브러리 설치 확인 및 자동 설치
-try:
-    import dotenv
-except ImportError:
-    print("python-dotenv 라이브러리가 설치되어 있지 않습니다. 설치를 시도합니다...")
-    try:
-        subprocess.check_call([sys.executable, "-m", "pip", "install", "python-dotenv"])
-        import dotenv
-        print("python-dotenv 설치 완료!")
-    except Exception as e:
-        print(f"python-dotenv 설치 실패: {e}")
-        print("수동으로 설치해주세요: pip install python-dotenv")
-        sys.exit(1)
-
-# openai 라이브러리 설치 확인 및 자동 설치
-try:
-    import openai
-except ImportError:
-    print("openai 라이브러리가 설치되어 있지 않습니다. 설치를 시도합니다...")
-    try:
-        subprocess.check_call([sys.executable, "-m", "pip", "install", "openai"])
-        import openai
-        print("openai 설치 완료!")
-    except Exception as e:
-        print(f"openai 설치 실패: {e}")
-        print("수동으로 설치해주세요: pip install openai")
-        sys.exit(1)
+import openai
+import dotenv
 
 def main():
     # .env 파일 로드
     dotenv.load_dotenv()
 
-    # 번역할 파일 경로 설정 (여기에서 직접 수정하세요)
-    input_file = "logging.md"  # 번역할 파일 경로
-    # 출력 파일명을 {원본파일명}-openai.md 형식으로 자동 생성
-    output_file = f"{os.path.splitext(input_file)[0]}-openai.md"  # 번역 결과를 저장할 파일 경로
-    source_lang = "EN"  # 원본 언어 코드 (EN: 영어, DE: 독일어 등)
-    target_lang = "ko"  # 대상 언어 코드 (ko: 한국어, ja: 일본어, zh: 중국어 등)
+    # 파일 경로 설정
+    input_file = "logging.md"
+    output_file = "logging-openai.md"
 
-    # 모델 설정
-    model = os.environ.get("TRANSLATION_MODEL", "o1")
-
-    # API 키 확인 (.env 파일에서 가져오기)
+    # OpenAI API 키 가져오기
     api_key = os.environ.get("OPENAI_API_KEY")
     if not api_key:
-        print("오류: OPENAI_API_KEY가 설정되지 않았습니다.")
-        print(".env 파일을 생성하고 다음 내용을 추가하세요:")
-        print("OPENAI_API_KEY=your_api_key_here")
+        print("OPENAI_API_KEY가 설정되지 않았습니다.")
         return
 
-    # OpenAI 클라이언트 설정
+    # 파일 읽기
+    with open(input_file, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    # OpenAI 번역
     openai.api_key = api_key
     client = openai.OpenAI()
 
-    # 입력 파일 확인
-    if not os.path.exists(input_file):
-        print(f"오류: 입력 파일 '{input_file}'이 존재하지 않습니다.")
-        return
-
-    try:
-        # 원본 파일 읽기
-        with open(input_file, 'r', encoding='utf-8') as f:
-            content = f.read()
-            print(f"파일 '{input_file}'을 읽었습니다. (크기: {len(content)} 바이트)")
-
-        # 시스템 프롬프트 설정
-        system_prompt = f"""당신은 전문 번역가입니다. {source_lang}에서 {target_lang}로 마크다운 문서를 번역해주세요.
+    # 시스템 프롬프트 설정
+    system_prompt = f"""당신은 전문 번역가입니다. EN에서 ko로 마크다운 문서를 번역해주세요.
 
 중요한 지침:
 1. 코드 블록, HTML 태그, 링크 URL은 번역하지 마세요.
@@ -77,36 +34,19 @@ def main():
 3. 전문 용어는 적절하게 번역하세요.
 """
 
-        # OpenAI API로 번역
-        print(f"OpenAI API를 사용하여 '{source_lang}'에서 '{target_lang}'로 번역 중...")
+    response = client.chat.completions.create(
+        model=os.environ.get("TRANSLATION_MODEL", "gpt-4.1"),
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": f"다음 마크다운 문서를 번역해주세요:\n\n{content}"}
+        ]
+    )
 
-        # API 요청 파라미터 설정
-        params = {
-            "model": model,
-            "messages": [
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": f"다음 마크다운 문서를 {target_lang}로 번역해주세요:\n\n{content}"}
-            ]
-        }
+    # 결과 저장
+    with open(output_file, 'w', encoding='utf-8') as f:
+        f.write(response.choices[0].message.content)
 
-        # API 호출
-        response = client.chat.completions.create(**params)
-
-        # 번역 결과 추출
-        translated_content = response.choices[0].message.content
-
-        # 토큰 사용량 출력
-        print(f"사용된 토큰: {response.usage.total_tokens}")
-
-        # 번역된 내용 저장
-        with open(output_file, 'w', encoding='utf-8') as f:
-            f.write(translated_content)
-
-        print(f"번역 완료! 결과가 '{output_file}'에 저장되었습니다.")
-        print(f"번역된 텍스트 크기: {len(translated_content)} 바이트")
-
-    except Exception as e:
-        print(f"오류 발생: {e}")
+    print(f"번역 완료: {output_file}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This pull request introduces two new Python scripts, `translate-deepl.py` and `translate-openai.py`, for translating Markdown files using the DeepL and OpenAI APIs, respectively. Both scripts include functionality for identifying translatable content, handling code blocks and non-translatable elements, and merging translations back into the original Markdown structure. Additionally, they handle library installation and API key configuration automatically.

### New Translation Scripts:

#### DeepL Translation (`sample/translate-deepl.py`):
* Implements translation of Markdown files using the DeepL API, preserving formatting and excluding code blocks, HTML tags, and other non-translatable elements.
* Automatically verifies and installs required libraries (`python-dotenv` and `deepl`) if not already installed.
* Includes error handling for missing API keys and input files, with guidance for setting up `.env` files.

#### OpenAI Translation (`sample/translate-openai.py`):
* Provides similar functionality as the DeepL script, but uses the OpenAI API for translation, supporting customizable models and chunking for long texts.
* Automatically verifies and installs required libraries (`python-dotenv` and `openai`) if not already installed.
* Includes detailed prompts for the OpenAI API to ensure accurate translations while preserving the original Markdown structure.